### PR TITLE
fix(beast): getting invalid_movement when generating proof

### DIFF
--- a/games/beast/beast1984/src/game.rs
+++ b/games/beast/beast1984/src/game.rs
@@ -390,11 +390,12 @@ impl Game {
                 if matches!(self.beat, Beat::Five) {
                     // beast movements
                     for idx in 0..self.common_beasts.len() {
+                        let old_pos = self.common_beasts[idx].position;
                         let action =
                             self.common_beasts[idx].advance(&mut self.board, self.player.position);
 
                         self.push_to_log(GameLogEntry::CommonBeastMoved {
-                            idx,
+                            old_pos,
                             new_pos: self.common_beasts[idx].position,
                         });
 
@@ -405,10 +406,12 @@ impl Game {
                         }
                     }
                     for idx in 0..self.super_beasts.len() {
+                        let old_pos = self.super_beasts[idx].position;
                         let action =
                             self.super_beasts[idx].advance(&mut self.board, self.player.position);
+
                         self.push_to_log(GameLogEntry::SuperBeastMoved {
-                            idx,
+                            old_pos,
                             new_pos: self.super_beasts[idx].position,
                         });
 

--- a/games/beast/beast1984/zkvm_program/src/main.rs
+++ b/games/beast/beast1984/zkvm_program/src/main.rs
@@ -108,9 +108,9 @@ fn prove_level_completed(input: &LevelLog) -> bool {
                     PlayerAction::None => {}
                 }
             }
-            GameLogEntry::CommonBeastMoved { idx, new_pos } => {
+            GameLogEntry::CommonBeastMoved { old_pos, new_pos } => {
                 let beast_action = common_beasts
-                    .get_mut(*idx)
+                    .iter_mut().find(|beast| beast.position == *old_pos)
                     .unwrap()
                     .advance_to(&mut board, player.position, *new_pos)
                     .unwrap();
@@ -120,9 +120,9 @@ fn prove_level_completed(input: &LevelLog) -> bool {
                     player.respawn(&mut board);
                 }
             }
-            GameLogEntry::SuperBeastMoved { idx, new_pos } => {
+            GameLogEntry::SuperBeastMoved { old_pos, new_pos } => {
                 let beast_action = super_beasts
-                    .get_mut(*idx)
+                    .iter_mut().find(|beast| beast.position == *old_pos)
                     .unwrap()
                     .advance_to(&mut board, player.position, *new_pos)
                     .unwrap();

--- a/games/beast/game_logic/src/proving.rs
+++ b/games/beast/game_logic/src/proving.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum GameLogEntry {
-    CommonBeastMoved { idx: usize, new_pos: Coord },
-    SuperBeastMoved { idx: usize, new_pos: Coord },
+    CommonBeastMoved { old_pos: Coord, new_pos: Coord },
+    SuperBeastMoved { old_pos: Coord, new_pos: Coord },
     HatchedBeastMoved { idx: usize, new_pos: Coord },
     PlayerMoved { dir: Dir },
 }


### PR DESCRIPTION
# Description

When the board is created in the zkvm, the index of the beasts is not always the same that the index assigned in the game execution. Then, when the program checks the movements, it may there be a false positive invalid movement.

To solve this, instead of use the index, we use the old_position of the beast to validate the movement (a cell can only contain one element, such as beast, player, wall, etc)

# How to Test

1. cd to beast directory

```
cd games/beast
```

2. Checkout to main branch

```
git checkout main
```

3.  Play and win at least one level.

```
make play_beast
```

You will get "InvalidMovement" sometimes.

4. Checkout to this branch

```
git checkout 17-fixbeast-getting-invalid_movement-when-generating-proof
```

5.  Play and win at least one level.

```
make play_beast
```

The proof should be generated correctly
