### PR TITLE
feat: save proofs status inside the database

### DIFF
--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -131,22 +131,6 @@ defmodule ZkArcade.BatcherConnection do
     }
   end
 
-  defp map_to_uint8_array(index_map) when is_map(index_map) do
-    indexed_values =
-      index_map
-      |> Enum.map(fn {k, v} -> {String.to_integer(k), v} end)
-      |> Enum.into(%{})
-
-    max_index = indexed_values |> Map.keys() |> Enum.max()
-
-    0..max_index
-    |> Enum.map(fn index ->
-      Map.get(indexed_values, index, 0)
-    end)
-  end
-
-  defp map_to_uint8_array(nil), do: nil
-
   defp parse_bigint(v) when is_binary(v) do
     String.to_integer(v)
   end

--- a/web/lib/zk_arcade/proofs.ex
+++ b/web/lib/zk_arcade/proofs.ex
@@ -8,6 +8,7 @@ defmodule ZkArcade.Proofs do
   alias ZkArcade.Proofs.Proof
   alias ZkArcade.Accounts
 
+  require Logger
   @doc """
   Returns the list of proofs.
 
@@ -52,7 +53,7 @@ defmodule ZkArcade.Proofs do
     |> Repo.all()
   end
 
-  defp create_pending_proof(submit_proof_message, address) do
+  def create_pending_proof(submit_proof_message, address) do
     proof_params = %{
       wallet_address: address,
       verification_data: submit_proof_message["verificationData"],
@@ -60,7 +61,7 @@ defmodule ZkArcade.Proofs do
       batch_data: nil
     }
 
-    Proofs.create_proof(proof_params)
+    create_proof(proof_params)
   end
 
   @doc """

--- a/web/lib/zk_arcade/proofs.ex
+++ b/web/lib/zk_arcade/proofs.ex
@@ -100,14 +100,14 @@ defmodule ZkArcade.Proofs do
     Repo.delete(proof)
   end
 
-  def update_proof_status_verified(proof_id, batch_data) do
+  def update_proof_status_submitted(proof_id, batch_data) do
     proof = get_proof!(proof_id)
 
-    changeset = change_proof(proof, %{status: "verified", batch_data: batch_data})
+    changeset = change_proof(proof, %{status: "submitted", batch_data: batch_data})
 
     case Repo.update(changeset) do
       {:ok, updated_proof} ->
-        Logger.info("Updated proof #{proof_id} status to verified")
+        Logger.info("Updated proof #{proof_id} status to submitted")
         {:ok, updated_proof}
 
       {:error, changeset} ->
@@ -116,14 +116,14 @@ defmodule ZkArcade.Proofs do
     end
   end
 
-  def update_proof_status_submitted(proof_id) do
+  def update_proof_status_claimed(proof_id) do
     proof = get_proof!(proof_id)
 
-    changeset = change_proof(proof, %{status: "submitted"})
+    changeset = change_proof(proof, %{status: "claimed"})
 
     case Repo.update(changeset) do
       {:ok, updated_proof} ->
-        Logger.info("Updated proof #{proof_id} status to submitted")
+        Logger.info("Updated proof #{proof_id} status to claimed")
         {:ok, updated_proof}
 
       {:error, changeset} ->

--- a/web/lib/zk_arcade/proofs.ex
+++ b/web/lib/zk_arcade/proofs.ex
@@ -100,14 +100,30 @@ defmodule ZkArcade.Proofs do
     Repo.delete(proof)
   end
 
-  def update_proof_status(proof_id, status, batch_data \\ nil) do
+  def update_proof_status_verified(proof_id, batch_data) do
     proof = get_proof!(proof_id)
 
-    changeset = change_proof(proof, %{status: status, batch_data: batch_data})
+    changeset = change_proof(proof, %{status: "verified", batch_data: batch_data})
 
     case Repo.update(changeset) do
       {:ok, updated_proof} ->
-        Logger.info("Updated proof #{proof_id} status to #{status}")
+        Logger.info("Updated proof #{proof_id} status to verified")
+        {:ok, updated_proof}
+
+      {:error, changeset} ->
+        Logger.error("Failed to update proof #{proof_id}: #{inspect(changeset)}")
+        {:error, changeset}
+    end
+  end
+
+  def update_proof_status_submitted(proof_id) do
+    proof = get_proof!(proof_id)
+
+    changeset = change_proof(proof, %{status: "submitted"})
+
+    case Repo.update(changeset) do
+      {:ok, updated_proof} ->
+        Logger.info("Updated proof #{proof_id} status to submitted")
         {:ok, updated_proof}
 
       {:error, changeset} ->

--- a/web/lib/zk_arcade/proofs/proof.ex
+++ b/web/lib/zk_arcade/proofs/proof.ex
@@ -9,6 +9,9 @@ defmodule ZkArcade.Proofs.Proof do
     # TODO: Store the commitments and th epub inputs instead of all the verification data
     field :verification_data, :map
     field :batch_data, :map
+    # Status can be "pending", "verified", submitted or "failed"
+    field :status, :string, default: "pending"
+
     belongs_to :wallet, Wallet, foreign_key: :wallet_address, references: :address, type: :string
 
     timestamps()
@@ -17,8 +20,9 @@ defmodule ZkArcade.Proofs.Proof do
   @doc false
   def changeset(proof, attrs) do
     proof
-    |> cast(attrs, [:verification_data, :wallet_address, :batch_data])
-    |> validate_required([:verification_data, :wallet_address])
+    |> cast(attrs, [:verification_data, :wallet_address, :batch_data, :status])
+    |> validate_required([:verification_data, :wallet_address, :status])
+    |> validate_inclusion(:status, ["pending", "verified", "failed", "submitted"])
     |> foreign_key_constraint(:wallet_address)
   end
 end

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -84,14 +84,12 @@ defmodule ZkArcadeWeb.ProofController do
 
         {:error, reason} ->
           Logger.error("Failed to send proof to the batcher: #{inspect(reason)}")
-          case Proofs.get_proof!(pending_proof.id) do
-            proof_to_delete ->
-              case Proofs.delete_proof(proof_to_delete) do
-                {:ok, _deleted_proof} ->
-                  Logger.info("Proof #{pending_proof.id} deleted successfully")
-                {:error, changeset} ->
-                  Logger.error("Failed to delete proof #{pending_proof.id} from database: #{inspect(changeset)}")
-              end
+          proof_to_delete = Proofs.get_proof!(pending_proof.id)
+          case Proofs.delete_proof(proof_to_delete) do
+            {:ok, _deleted_proof} ->
+              Logger.info("Proof #{pending_proof.id} deleted successfully")
+            {:error, changeset} ->
+              Logger.error("Failed to delete proof #{pending_proof.id} from database: #{inspect(changeset)}")
           end
           {:error, reason}
       end

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -73,7 +73,7 @@ defmodule ZkArcadeWeb.ProofController do
       Logger.info("Proof created successfully with ID: #{pending_proof.id} with pending state")
       case BatcherConnection.send_submit_proof_message(submit_proof_message, address) do
         {:ok, {:batch_inclusion, batch_data}} ->
-          case Proofs.update_proof_status_verified(pending_proof.id, batch_data) do
+          case Proofs.update_proof_status_submitted(pending_proof.id, batch_data) do
             {:ok, updated_proof} ->
               Logger.info("Proof #{pending_proof.id} verified and updated successfully")
               {:ok, updated_proof}

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -36,7 +36,7 @@ defmodule ZkArcadeWeb.ProofController do
 
       # Note: The proof creation is done here because we need the proof id to modify the proof state later,
       # which is passed to the task below
-      {:ok, pending_proof} = case create_pending_proof(submit_proof_message, address) do
+      {:ok, pending_proof} = case Proofs.create_pending_proof(submit_proof_message, address) do
         {:ok, pending_proof} ->
           Logger.info("Proof created successfully with ID: #{pending_proof.id} with pending state")
         {:error, changeset} ->

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -62,6 +62,7 @@ defmodule ZkArcadeWeb.ProofController do
 
         {:ok, {:error, reason}} ->
           Logger.error("Failed to send proof to batcher on async task: #{inspect(reason)}")
+          Proofs.update_proof_status(pending_proof.id, "failed", nil)
           conn
           |> put_flash(:error, "Failed to submit proof: #{inspect(reason)}")
           |> redirect(to: "/")
@@ -88,6 +89,7 @@ defmodule ZkArcadeWeb.ProofController do
 
       {:error, reason} ->
         Logger.error("Failed to send proof to the batcher: #{inspect(reason)}")
+        Proofs.update_proof_status(proof_id, "failed", nil)
         {:error, reason}
     end
   end

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -73,7 +73,7 @@ defmodule ZkArcadeWeb.ProofController do
       Logger.info("Proof created successfully with ID: #{pending_proof.id} with pending state")
       case BatcherConnection.send_submit_proof_message(submit_proof_message, address) do
         {:ok, {:batch_inclusion, batch_data}} ->
-          case Proofs.update_proof_status(pending_proof.id, "verified", batch_data) do
+          case Proofs.update_proof_status_verified(pending_proof.id, batch_data) do
             {:ok, updated_proof} ->
               Logger.info("Proof #{pending_proof.id} verified and updated successfully")
               {:ok, updated_proof}

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -36,16 +36,19 @@ defmodule ZkArcadeWeb.ProofController do
 
       # Note: The proof creation is done here because we need the proof id to modify the proof state later,
       # which is passed to the task below
-      {:ok, pending_proof} = case Proofs.create_pending_proof(submit_proof_message, address) do
-        {:ok, pending_proof} ->
-          Logger.info("Proof created successfully with ID: #{pending_proof.id} with pending state")
-        {:error, changeset} ->
-          Logger.error("Failed to create proof: #{inspect(changeset)}")
-          conn
-          |> put_flash(:error, "Failed to create proof")
-          |> redirect(to: "/")
-          |> halt()
-      end
+      pending_proof =
+        case Proofs.create_pending_proof(submit_proof_message, address) do
+          {:ok, pending_proof} ->
+            Logger.info("Proof created successfully with ID: #{pending_proof.id} with pending state")
+            pending_proof
+
+          {:error, changeset} ->
+            Logger.error("Failed to create proof: #{inspect(changeset)}")
+            conn
+            |> put_flash(:error, "Failed to create proof")
+            |> redirect(to: "/")
+            |> halt()
+        end
 
       Logger.info("Message decoding successful, sending message on an async task.")
       task = Task.Supervisor.async_nolink(ZkArcade.TaskSupervisor, fn ->

--- a/web/priv/repo/migrations/20241218184947_create_wallets.exs
+++ b/web/priv/repo/migrations/20241218184947_create_wallets.exs
@@ -7,6 +7,8 @@ defmodule ZkArcade.Repo.Migrations.CreateWallets do
       add :address, :string
       add :points, :integer, default: 0, null: false
       add :balance, :float, default: 0.0, null: false
+
+      timestamps()
     end
 
     create unique_index(:wallets, :address, name: :wallets_address_index)

--- a/web/priv/repo/migrations/20250708155806_create_proofs.exs
+++ b/web/priv/repo/migrations/20250708155806_create_proofs.exs
@@ -6,6 +6,7 @@ defmodule ZkArcade.Repo.Migrations.CreateProofs do
       add :id, :binary_id, primary_key: true
       add :verification_data, :map, null: false
       add :batch_data, :map
+      add :status, :string, null: false, default: "pending"
       add :wallet_address, references(:wallets, column: :address, type: :string), null: false
 
       timestamps()

--- a/web/priv/repo/migrations/20250711204531_add_timestamps_to_wallets.exs
+++ b/web/priv/repo/migrations/20250711204531_add_timestamps_to_wallets.exs
@@ -1,9 +1,0 @@
-defmodule ZkArcade.Repo.Migrations.AddTimestampsToWallets do
-  use Ecto.Migration
-
-  def change do
-    alter table(:wallets) do
-      timestamps()
-    end
-  end
-end

--- a/web/priv/repo/migrations/20250715200733_add_status_to_proofs.exs
+++ b/web/priv/repo/migrations/20250715200733_add_status_to_proofs.exs
@@ -1,0 +1,9 @@
+defmodule ZkArcade.Repo.Migrations.AddStatusToProofs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:proofs) do
+      add :status, :string, null: false, default: "pending"
+    end
+  end
+end

--- a/web/priv/repo/migrations/20250715200733_add_status_to_proofs.exs
+++ b/web/priv/repo/migrations/20250715200733_add_status_to_proofs.exs
@@ -1,9 +1,0 @@
-defmodule ZkArcade.Repo.Migrations.AddStatusToProofs do
-  use Ecto.Migration
-
-  def change do
-    alter table(:proofs) do
-      add :status, :string, null: false, default: "pending"
-    end
-  end
-end


### PR DESCRIPTION
This PR adds the status flag to the proof schema, which represents the proof status in the system. This flag can have one of the following values:
- pending: For those proofs waiting for a response from the batcher
- verified: For those proofs that were verified after the call to the batcher
- failed: For those proofs for which the verification process failed
- submitted: For those proofs already submitted to the Leaderboard contract

An improvement that could be done is that, when batcher returns a `:connection_down` response, we mark it with a field representing that the proof sending should be retried.

# How to Test

1. First, deploy Aligned locally. The steps are the following:
    1. `make anvil_start`
    2. `make aggregator_start ENVIRONMENT=devnet`
    3. `make operator_full_registration_and_start ENVIRONMENT=devnet`
    4. `make batcher_start_local`
    5. You can create an explorer to view the batches status by running `make explorer_build_db` and then `make explorer_start`.

2. Fund your address acount by sending funds from one of the Anvil rich accounts (in this case the first):
```
cast send <your-account-address> --value 10ether --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-url http://localhost:8545
```

3. In the zk-arcade folder, run
```
make web_run
```
to create the database and deploy the page.

4. Go to http://localhost:4005/, where the page will be deployed.

5. The workflow inside the web page is the following

    1. Connect your wallet by pressing the Connect Wallet button. That will redirect you to the /terms-conditions subpage.
    2. Press the Connect your wallet and sign button, which will redirect you to the /sign subpage, where the wallet connection integration lies.
    3. Then you should connect your funded wallet and sign the agreement. After it, you will be redirected to the home page.
    4. On the home page, you'll see that you have no funds in the batcher payment service, so you will use the send funds menu to fund your account in the batcher payment service.
    7. With your account funded, you can submit your proofs to the batcher by clicking the submit proofs button.
    8. Upload the files for the Gnark Groth 16 proof, you can find them in web/priv/proofs/gnark_groth16 . Send them to the batcher by clicking the send proofs button.

6. You'll have to submit more proofs if you want to make the batch fee to decrease until reach the max fee defined for the uploaded proof. I've been testing the system with 
```
make batcher_send_gnark_groth16_bn254_infinite
```
to upload the proofs without worrying on errors about repeated batches.

### Query the DB

To get the values from the database, you can use the iex terminal where you run the `make web_run` command, and call the methods from the ZkArcade.Proofs module, for example:
- `ZkArcade.Proofs.list_proofs()` will list all the proofs in the DB
- `ZkArcade.Proofs.get_proof!(<id>)` will get the proof for the id passed as a parameter
- `ZkArcade.Proofs.get_proofs_by_address(<address>)` will list the proofs for the address passed as a parameter
