### PR TITLE
fix: notify connection close to the batcher

### DIFF
--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -33,7 +33,7 @@ defmodule ZkArcade.BatcherConnection do
 
       {:gun_response, ^conn_pid, ^stream_ref, _, status, headers} ->
         Logger.error("Upgrade failed: #{status}, headers: #{inspect(headers)}")
-        :gun.close(conn_pid)
+        close_connection(conn_pid, stream_ref)
         {:error, :upgrade_failed}
     after
       25_000 ->
@@ -87,18 +87,18 @@ defmodule ZkArcade.BatcherConnection do
 
       %{"InsufficientBalance" => address} ->
         Logger.error("Insufficient balance for address #{address}")
-        :gun.close(conn_pid)
+        close_connection(conn_pid, stream_ref)
         {:error, {:insufficient_balance, address}}
 
       %{"InvalidProof" => reason} ->
         Logger.error("There was a problem with the submited proof: #{reason}")
-        :gun.close(conn_pid)
+        close_connection(conn_pid, stream_ref)
         {:error, "Invalid proof - #{reason}"}
 
       # There can be more error messages from the batcher, but they will enter on the other clause
       other ->
         Logger.error("Unrecognized message from batcher: #{inspect(other)}")
-        :gun.close(conn_pid)
+        close_connection(conn_pid, stream_ref)
         {:error, {:unrecognized_message, other}}
     end
   end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -132,6 +132,7 @@ defmodule ZkArcade.BatcherConnection do
   end
 
   defp close_connection(conn_pid, stream_ref) do
+    Logger.info("Closing the connection with the batcher...")
     :gun.ws_send(conn_pid, stream_ref, {:close, 1000, ""})
     receive do
       {:gun_ws, ^conn_pid, ^stream_ref, {:close, _code, _reason}} ->

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -54,7 +54,7 @@ defmodule ZkArcade.BatcherConnection do
           {:error, reason} ->
             Logger.error("Failed to decode CBOR message: #{inspect(reason)}")
             Logger.error("Raw message: #{inspect(msg)}")
-            :gun.close(conn_pid)
+            close_connection(conn_pid, stream_ref)
             {:error, :decode_error}
         end
 
@@ -82,7 +82,7 @@ defmodule ZkArcade.BatcherConnection do
 
       %{"BatchInclusionData" => batch_data} ->
         Logger.info("Proof submitted successfully - BatchInclusionData: #{inspect(batch_data)}")
-        :gun.close(conn_pid)
+        close_connection(conn_pid, stream_ref)
         {:ok, {:batch_inclusion, batch_data}}
 
       %{"InsufficientBalance" => address} ->

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -131,6 +131,14 @@ defmodule ZkArcade.BatcherConnection do
     }
   end
 
+  defp close_connection(conn_pid, stream_ref) do
+    :gun.ws_send(conn_pid, stream_ref, {:close, 1000, ""})
+    receive do
+      {:gun_ws, ^conn_pid, ^stream_ref, {:close, _code, _reason}} ->
+        :gun.close(conn_pid)
+    end
+  end
+
   defp parse_bigint(v) when is_binary(v) do
     String.to_integer(v)
   end


### PR DESCRIPTION
This PR fixes the error the batcher had in connection with the backend. In those errors, the log was `ERROR aligned_batcher] Unexpected error: WebSocket protocol error: Connection reset without closing handshake`, which happened because the backend wasn't notifying the batcher about the close of the connection before closing the socket. This PR replaces the simple close with a close_connection function that also sends a close message to the batcher.

### How to test

First, checkout the main branch, to watch the error happening. Then, follow these steps:

1. Set up the aligned infrastructure: 

``` shell
make anvil_start
make aggregator_start ENVIRONMENT=devnet
make operator_full_registration CONFIG_FILE=config-files/config-operator-1.yaml ENVIRONMENT=devnet 
make operator_start CONFIG_FILE=config-files/config-operator-1.yaml ENVIRONMENT=devnet
make batcher_start_local
```

2. In the zk-arcade folder, run

``` shell
make web_run
```

to create the database and deploy the page.

3. Go to http://localhost:4005/, where the page will be deployed. 

4. For this short test case, connect your wallet and go directly to submit your proof (because we want to trigger an error). You will see these logs:

```
[2025-07-17T14:38:34Z INFO  aligned_batcher] Incoming TCP connection from: [::1]:61790
[2025-07-17T14:38:34Z INFO  aligned_batcher] Handling message
[2025-07-17T14:38:34Z ERROR aligned_batcher] Unexpected error: WebSocket protocol error: Connection reset without closing handshake
```

This happened because the backend closed the connection unexpectedly. If you now check out the branch of this PR (`notify-connection-close-backend-batcher`), and repeat steps 3 and 4, you'll see these other logs:

```
[2025-07-17T14:44:17Z INFO  aligned_batcher] Incoming TCP connection from: [::1]:61870
[2025-07-17T14:44:18Z INFO  aligned_batcher] Handling message
[2025-07-17T14:44:18Z INFO  aligned_batcher] [::1]:61870 disconnected
```

That means the connection closed without errors.