### PR TITLE
chore: bump risc0 to v2.3.0

### DIFF
--- a/games/beast/Cargo.lock
+++ b/games/beast/Cargo.lock
@@ -1175,7 +1175,7 @@ dependencies = [
  "rand 0.9.1",
  "reqwest 0.12.20",
  "risc0-build",
- "risc0-zkvm 2.1.0",
+ "risc0-zkvm 2.3.1",
  "ron",
  "serde",
  "time",
@@ -4913,9 +4913,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4923,8 +4923,8 @@ dependencies = [
  "elf",
  "lazy_static",
  "postcard",
- "risc0-zkp 2.0.1",
- "risc0-zkvm-platform 2.0.2",
+ "risc0-zkp 2.0.2",
+ "risc0-zkvm-platform 2.0.3",
  "semver 1.0.26",
  "serde",
  "tracing",
@@ -4932,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.1.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17d6657b1fb615c0482bd4b57aae7850911ed7dbdc8e783df20e93f33209a8f"
+checksum = "62ffc0f135e6c1e9851e7e19438d03ff41a9d49199ee4f6c17b8bb30b4f83910"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -4942,10 +4942,10 @@ dependencies = [
  "dirs",
  "docker-generate",
  "hex",
- "risc0-binfmt 2.0.1",
+ "risc0-binfmt 2.0.2",
  "risc0-zkos-v1compat 2.0.1",
- "risc0-zkp 2.0.1",
- "risc0-zkvm-platform 2.0.2",
+ "risc0-zkp 2.0.2",
+ "risc0-zkvm-platform 2.0.3",
  "rzup",
  "semver 1.0.26",
  "serde",
@@ -4971,17 +4971,17 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
  "paste",
- "risc0-binfmt 2.0.1",
- "risc0-circuit-recursion 2.0.2",
+ "risc0-binfmt 2.0.2",
+ "risc0-circuit-recursion 3.0.0",
  "risc0-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "risc0-zkp 2.0.1",
+ "risc0-zkp 2.0.2",
  "tracing",
 ]
 
@@ -5001,16 +5001,16 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
  "hex",
  "metal",
  "risc0-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "risc0-zkp 2.0.1",
+ "risc0-zkp 2.0.2",
  "tracing",
 ]
 
@@ -5033,18 +5033,18 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "bit-vec 0.8.0",
  "bytemuck",
  "derive_more 2.0.1",
  "paste",
- "risc0-binfmt 2.0.1",
+ "risc0-binfmt 2.0.2",
  "risc0-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "risc0-zkp 2.0.1",
+ "risc0-zkp 2.0.2",
  "serde",
  "tracing",
 ]
@@ -5092,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -5105,8 +5105,8 @@ dependencies = [
  "hex",
  "num-bigint",
  "num-traits",
- "risc0-binfmt 2.0.1",
- "risc0-zkp 2.0.1",
+ "risc0-binfmt 2.0.2",
+ "risc0-zkp 2.0.2",
  "serde",
  "stability",
 ]
@@ -5156,9 +5156,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5172,7 +5172,7 @@ dependencies = [
  "paste",
  "rand_core 0.6.4",
  "risc0-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "risc0-zkvm-platform 2.0.2",
+ "risc0-zkvm-platform 2.0.3",
  "serde",
  "sha2",
  "stability",
@@ -5209,9 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "9684b333c1c5d83f29ce2a92314ccfafd9d8cdfa6c4e19c07b97015d2f1eb9d0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5224,16 +5224,16 @@ dependencies = [
  "hex",
  "lazy-regex",
  "prost",
- "risc0-binfmt 2.0.1",
+ "risc0-binfmt 2.0.2",
  "risc0-build",
- "risc0-circuit-keccak 2.0.2",
- "risc0-circuit-recursion 2.0.2",
- "risc0-circuit-rv32im 2.0.4",
+ "risc0-circuit-keccak 3.0.0",
+ "risc0-circuit-recursion 3.0.0",
+ "risc0-circuit-rv32im 3.0.0",
  "risc0-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "risc0-groth16 2.0.1",
+ "risc0-groth16 2.0.2",
  "risc0-zkos-v1compat 2.0.1",
- "risc0-zkp 2.0.1",
- "risc0-zkvm-platform 2.0.2",
+ "risc0-zkp 2.0.2",
+ "risc0-zkvm-platform 2.0.3",
  "rrs-lib",
  "rzup",
  "semver 1.0.26",
@@ -5258,9 +5258,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/games/beast/beast1984/Cargo.toml
+++ b/games/beast/beast1984/Cargo.toml
@@ -40,7 +40,7 @@ time = { version = "0.3", features = [
 	"local-offset",
 ] }
 game_logic = { path = "../game_logic", features = [] }
-risc0-zkvm = "2.1.0"
+risc0-zkvm = "2.3.0"
 bincode = "1.3.3"
 alloy = { version = "0.15", features = ["default", "signer-keystore"] }
 aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer/", rev = "8a3a6448c974d09c645f3b74d4c9ff9d2dd27249" }
@@ -52,5 +52,4 @@ tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 methods = ["./zkvm_program/"]
 
 [build-dependencies]
-risc0-build = { version = "2.1.0" }
-
+risc0-build = { version = "2.3.0" }


### PR DESCRIPTION
**Description**
Bump risc0 to `v2.3.0` as Aligned has also been updated.