### PR TITLE
fix IPv6 addressing on batcher connection

### DIFF
--- a/web/config/dev.exs
+++ b/web/config/dev.exs
@@ -90,5 +90,5 @@ config :ethereumex,
 
 config :zk_arcade, :network, "anvil"
 
-config :zk_arcade, :batcher_host, "localhost"
+config :zk_arcade, :batcher_host, "127.0.0.1"
 config :zk_arcade, :batcher_port, 8080

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -13,7 +13,9 @@ defmodule ZkArcade.BatcherConnection do
           conn_pid
 
         {:error, :timeout} ->
-          {:ok, new_conn_pid} = :gun.open({0, 0, 0, 0, 0, 0, 0, 1}, 8080)
+          Logger.info("Connection timed out, trying connecting with IPv6")
+          ipv6_address = ipv4_to_ipv6(batcher_host)
+          {:ok, new_conn_pid} = :gun.open(ipv6_address, 8080)
           {:ok, _protocol} = :gun.await_up(new_conn_pid)
           new_conn_pid
       end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -161,8 +161,11 @@ defmodule ZkArcade.BatcherConnection do
     segment8 = c * 256 + d
     {0, 0, 0, 0, 0, 0xFFFF, segment7, segment8}
   end
-  defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
-    {:ok, tuple} = :inet.parse_address(String.to_charlist(ipv4))
+  defp ipv4_to_ipv6(ipv4) when is_list(ipv4) do
+    {:ok, tuple} = :inet.parse_address(ipv4)
     ipv4_to_ipv6(tuple)
+  end
+  defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
+    ipv4_to_ipv6(String.to_charlist(ipv4))
   end
 end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -13,7 +13,7 @@ defmodule ZkArcade.BatcherConnection do
           conn_pid
 
         {:error, :timeout} ->
-          Logger.info("Connection timed out, trying connecting with IPv6")
+          Logger.info("Connection timed out, trying to connect with IPv6.")
           ipv6_address = ipv4_to_ipv6(batcher_host)
           {:ok, new_conn_pid} = :gun.open(ipv6_address, 8080)
           {:ok, _protocol} = :gun.await_up(new_conn_pid)

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -151,13 +151,14 @@ defmodule ZkArcade.BatcherConnection do
 
   defp parse_bigint(v) when is_integer(v), do: v
 
-  defp ipv4_to_ipv6(ipv4) when is_tuple(ipv4) do
-    {a, b, c, d} = ipv4
-    {0, 0, 0, 0, 0, 0, a, b * 256 + c * 16 + d}
+  # Converts an IPv4 address to an IPv6 address by padding the first 6 segments with zeros
+  # and placing the IPv4 address in the last two segments.
+  # Note: the returned address is an IPv4 mapped IPv6 address.
+  defp ipv4_to_ipv6({a, b, c, d}) do
+    {0, 0, 0, 0, 0, 0xFFFF, (a * 16_777_216) + (b * 65_536) + (c * 256) + d}
   end
   defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
-    {a, b, c, d} = :inet.parse_ipv4(ipv4)
+    {:ok, {a, b, c, d}} = :inet.parse_address(String.to_charlist(ipv4))
     ipv4_to_ipv6({a, b, c, d})
   end
-
 end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -15,7 +15,7 @@ defmodule ZkArcade.BatcherConnection do
         {:error, :timeout} ->
           Logger.info("Connection timed out, trying to connect with IPv6.")
           ipv6_address = ipv4_to_ipv6(batcher_host)
-          {:ok, new_conn_pid} = :gun.open(ipv6_address, 8080)
+          {:ok, new_conn_pid} = :gun.open(ipv6_address, batcher_port)
           {:ok, _protocol} = :gun.await_up(new_conn_pid)
           new_conn_pid
       end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -155,10 +155,12 @@ defmodule ZkArcade.BatcherConnection do
   # and placing the IPv4 address in the last two segments.
   # Note: the returned address is an IPv4 mapped IPv6 address.
   defp ipv4_to_ipv6({a, b, c, d}) do
-    {0, 0, 0, 0, 0, 0xFFFF, (a * 16_777_216) + (b * 65_536) + (c * 256) + d}
+    segment7 = a * 256 + b
+    segment8 = c * 256 + d
+    {0, 0, 0, 0, 0, 0xFFFF, segment7, segment8}
   end
   defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
-    {:ok, {a, b, c, d}} = :inet.parse_address(String.to_charlist(ipv4))
-    ipv4_to_ipv6({a, b, c, d})
+    {:ok, tuple} = :inet.parse_address(String.to_charlist(ipv4))
+    ipv4_to_ipv6(tuple)
   end
 end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -103,6 +103,9 @@ defmodule ZkArcade.BatcherConnection do
     end
   end
 
+  # Builds the message that will be sent to the batcher
+  # It is built this way to match the struct expected by the batcher after
+  # the CBOR encoding/decoding process
   defp build_submit_proof_message(submit_proof_message, _address) do
     verification_data = submit_proof_message["verificationData"]["verificationData"]
 
@@ -131,6 +134,8 @@ defmodule ZkArcade.BatcherConnection do
     }
   end
 
+  # Closes the connection with the batcher notifying it with a close message and waits
+  # for the confirmation of the close message before closing the connection
   defp close_connection(conn_pid, stream_ref) do
     Logger.info("Closing the connection with the batcher...")
     :gun.ws_send(conn_pid, stream_ref, {:close, 1000, ""})

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -150,4 +150,10 @@ defmodule ZkArcade.BatcherConnection do
   end
 
   defp parse_bigint(v) when is_integer(v), do: v
+
+  defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
+    {a, b, c, d} = :inet.parse_ipv4(ipv4)
+    ipv4_to_ipv6({a, b, c, d})
+  end
+
 end

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -151,6 +151,10 @@ defmodule ZkArcade.BatcherConnection do
 
   defp parse_bigint(v) when is_integer(v), do: v
 
+  defp ipv4_to_ipv6(ipv4) when is_tuple(ipv4) do
+    {a, b, c, d} = ipv4
+    {0, 0, 0, 0, 0, 0, a, b * 256 + c * 16 + d}
+  end
   defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
     {a, b, c, d} = :inet.parse_ipv4(ipv4)
     ipv4_to_ipv6({a, b, c, d})


### PR DESCRIPTION
This PR modifies the handling of the IPv6 connection with the batcher in case the IPv4 one fails. Previously, the value was hardcoded, but now we convert the IPv4 address to an IPv6 one to connect to batchers which only accept IPv6.

It also adds some doc comments to the batcher connection module.