### PR TITLE
fix the IPv6 addressing and use localhost

### DIFF
--- a/web/config/dev.exs
+++ b/web/config/dev.exs
@@ -90,5 +90,5 @@ config :ethereumex,
 
 config :zk_arcade, :network, "anvil"
 
-config :zk_arcade, :batcher_host, "127.0.0.1"
+config :zk_arcade, :batcher_host, "localhost"
 config :zk_arcade, :batcher_port, 8080

--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -14,7 +14,7 @@ defmodule ZkArcade.BatcherConnection do
 
         {:error, :timeout} ->
           Logger.info("Connection timed out, trying to connect with IPv6.")
-          ipv6_address = ipv4_to_ipv6(batcher_host)
+          {:ok, ipv6_address} = :inet.getaddr(batcher_host, :inet6)
           {:ok, new_conn_pid} = :gun.open(ipv6_address, batcher_port)
           {:ok, _protocol} = :gun.await_up(new_conn_pid)
           new_conn_pid
@@ -152,20 +152,4 @@ defmodule ZkArcade.BatcherConnection do
   end
 
   defp parse_bigint(v) when is_integer(v), do: v
-
-  # Converts an IPv4 address to an IPv6 address by padding the first 6 segments with zeros
-  # and placing the IPv4 address in the last two segments.
-  # Note: the returned address is an IPv4 mapped IPv6 address.
-  defp ipv4_to_ipv6({a, b, c, d}) do
-    segment7 = a * 256 + b
-    segment8 = c * 256 + d
-    {0, 0, 0, 0, 0, 0xFFFF, segment7, segment8}
-  end
-  defp ipv4_to_ipv6(ipv4) when is_list(ipv4) do
-    {:ok, tuple} = :inet.parse_address(ipv4)
-    ipv4_to_ipv6(tuple)
-  end
-  defp ipv4_to_ipv6(ipv4) when is_binary(ipv4) do
-    ipv4_to_ipv6(String.to_charlist(ipv4))
-  end
 end


### PR DESCRIPTION
The batcher host used on env file should be `localhost` instead of `127.0.0.1`, to cover not only IPv4 addressing, but also IPv6 one. After making this cange, I noticed that the address conversion from IPv4 to IPv6 was not really needed, since the host the batcher uses depends on the batcher, not in the web backend. For those reasons replaced the IPv4 to IPv6 conversion logic for a function from the `inet` module, that receives an URL and converts it to an IPv6 address, but just in case the original host address fails.