### PR TITLE
reset proof inserted at timestamp on send retry

### DIFF
--- a/web/assets/js/react/modules/Wallet/Notifications.tsx
+++ b/web/assets/js/react/modules/Wallet/Notifications.tsx
@@ -246,16 +246,24 @@ export const NotificationBell = ({
 						className="overflow-scroll flex flex-col gap-4"
 						style={{ maxHeight: 200 }}
 					>
-						{allProofs.map(proof => (
-							<NotificationEntry
-								proof={proof}
-								leaderboard_address={leaderboard_address}
-								payment_service_address={
-									payment_service_address
-								}
-								user_address={user_address}
-							/>
-						))}
+						{allProofs.length > 0 ? (
+							allProofs.map(proof => (
+								<NotificationEntry
+									proof={proof}
+									leaderboard_address={leaderboard_address}
+									payment_service_address={
+										payment_service_address
+									}
+									user_address={user_address}
+								/>
+							))
+						) : (
+							<p className="text-sm text-text-200">
+								No updates at the moment. We'll notify you if
+								there are any changes to the status of your
+								proofs.
+							</p>
+						)}
 					</div>
 				</div>
 			</div>

--- a/web/assets/js/react/modules/Wallet/ProofSubmissions.tsx
+++ b/web/assets/js/react/modules/Wallet/ProofSubmissions.tsx
@@ -34,9 +34,11 @@ const statusText: { [key in ProofSubmission["status"]]: string } = {
 const Proof = ({
 	proof,
 	leaderboard_address,
+	payment_service_address,
 }: {
 	proof: ProofSubmission;
 	leaderboard_address: Address;
+	payment_service_address: Address;
 }) => {
 	const { csrfToken } = useCSRFToken();
 	const formRefSubmitted = useRef<HTMLFormElement>(null);
@@ -100,7 +102,7 @@ const Proof = ({
 
 		proof.verificationData.maxFee = toHex(maxFee, { size: 32 });
 
-		const { r, s, v } = await signVerificationData(proof.verificationData);
+		const { r, s, v } = await signVerificationData(proof.verificationData, payment_service_address);
 
 		const submitProofMessage: SubmitProof = {
 			verificationData: proof.verificationData,
@@ -257,11 +259,13 @@ const Proof = ({
 type Props = {
 	proofs: ProofSubmission[];
 	leaderboard_address: Address;
+	payment_service_address: Address;
 };
 
 export const ProofSubmissions = ({
 	proofs = [],
 	leaderboard_address,
+	payment_service_address
 }: Props) => {
 	return (
 		<div>
@@ -285,6 +289,9 @@ export const ProofSubmissions = ({
 										proof={proof}
 										leaderboard_address={
 											leaderboard_address
+										}
+										payment_service_address={
+											payment_service_address
 										}
 									/>
 								))}

--- a/web/assets/js/react/modules/Wallet/WalletInfo.tsx
+++ b/web/assets/js/react/modules/Wallet/WalletInfo.tsx
@@ -56,6 +56,7 @@ export const WalletInfo = ({
 					<ProofSubmissions
 						proofs={proofs}
 						leaderboard_address={leaderboard_address}
+						payment_service_address={payment_service_address}
 					/>
 					<div>
 						<form

--- a/web/assets/js/react/utils/date.ts
+++ b/web/assets/js/react/utils/date.ts
@@ -1,5 +1,5 @@
 export const timeAgo = (dateString: string) => {
-	const pastDate = new Date(dateString);
+	const pastDate = new Date(dateString + "Z");
 	const diffInMs = Date.now() - pastDate.getTime();
 
 	const seconds = Math.floor(diffInMs / 1000);
@@ -19,8 +19,10 @@ export const timeAgo = (dateString: string) => {
 };
 
 export const timeAgoInHs = (dateString: string) => {
-	const pastDate = new Date(dateString);
-	const diffInMs = Date.now() - pastDate.getTime();
+	const pastDate = new Date(dateString + "Z");
+
+	const nowUtc = Date.now();
+	const diffInMs = nowUtc - pastDate.getTime();
 	const hours = Math.floor(diffInMs / (1000 * 60 * 60));
 
 	return hours;

--- a/web/lib/zk_arcade/proofs.ex
+++ b/web/lib/zk_arcade/proofs.ex
@@ -174,7 +174,12 @@ defmodule ZkArcade.Proofs do
   def update_proof_retry(proof_id) do
     proof = get_proof!(proof_id)
 
-    changeset = change_proof(proof, %{status: "pending", inserted_at: DateTime.utc_now()})
+    changeset = change_proof(proof, %{
+      status: "pending",
+      inserted_at: DateTime.utc_now(),
+      updated_at: DateTime.utc_now(),
+      times_retried: proof.times_retried + 1
+    })
 
     case Repo.update(changeset) do
       {:ok, updated_proof} ->

--- a/web/lib/zk_arcade/proofs.ex
+++ b/web/lib/zk_arcade/proofs.ex
@@ -171,6 +171,22 @@ defmodule ZkArcade.Proofs do
     end
   end
 
+  def update_proof_retry(proof_id) do
+    proof = get_proof!(proof_id)
+
+    changeset = change_proof(proof, %{status: "pending", inserted_at: DateTime.utc_now()})
+
+    case Repo.update(changeset) do
+      {:ok, updated_proof} ->
+        Logger.info("Updated proof #{proof_id} status to pending for retry")
+        {:ok, updated_proof}
+
+      {:error, changeset} ->
+        Logger.error("Failed to update proof #{proof_id}: #{inspect(changeset)}")
+        {:error, changeset}
+    end
+  end
+
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking proof changes.
 

--- a/web/lib/zk_arcade/proofs/proof.ex
+++ b/web/lib/zk_arcade/proofs/proof.ex
@@ -13,6 +13,8 @@ defmodule ZkArcade.Proofs.Proof do
     field :game, :string, default: "Beast"
     field :proving_system, :string, default: "risc0"
 
+    field :times_retried, :integer, default: 0
+
     belongs_to :wallet, Wallet, foreign_key: :wallet_address, references: :address, type: :string
 
     timestamps()
@@ -21,7 +23,7 @@ defmodule ZkArcade.Proofs.Proof do
   @doc false
   def changeset(proof, attrs) do
     proof
-    |> cast(attrs, [:verification_data, :wallet_address, :batch_data, :status, :game, :proving_system, :inserted_at, :updated_at])
+    |> cast(attrs, [:verification_data, :wallet_address, :batch_data, :status, :game, :proving_system, :inserted_at, :updated_at, :times_retried])
     |> validate_required([:verification_data, :wallet_address, :status, :game, :proving_system])
     |> validate_inclusion(:status, ["pending", "submitted", "failed", "claimed"])
     |> validate_inclusion(:game, ["Beast", "Sudoku", "Parity"])

--- a/web/lib/zk_arcade/proofs/proof.ex
+++ b/web/lib/zk_arcade/proofs/proof.ex
@@ -21,11 +21,20 @@ defmodule ZkArcade.Proofs.Proof do
   @doc false
   def changeset(proof, attrs) do
     proof
-    |> cast(attrs, [:verification_data, :wallet_address, :batch_data, :status, :game, :proving_system])
+    |> cast(attrs, [:verification_data, :wallet_address, :batch_data, :status, :game, :proving_system, :inserted_at, :updated_at])
     |> validate_required([:verification_data, :wallet_address, :status, :game, :proving_system])
     |> validate_inclusion(:status, ["pending", "submitted", "failed", "claimed"])
     |> validate_inclusion(:game, ["Beast", "Sudoku", "Parity"])
     |> validate_inclusion(:proving_system, ["risc0", "groth16", "stark", "plonk", "sp1"])
     |> foreign_key_constraint(:wallet_address)
+    |> update_timestamps(attrs)
   end
+
+  defp update_timestamps(changeset, %{"inserted_at" => ins, "updated_at" => up}) do
+    changeset
+    |> put_change(:inserted_at, ins)
+    |> put_change(:updated_at, up)
+  end
+
+  defp update_timestamps(changeset, _), do: changeset
 end

--- a/web/lib/zk_arcade_web/controllers/page_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/page_controller.ex
@@ -16,7 +16,7 @@ defmodule ZkArcadeWeb.PageController do
       wallet
   end
 
-  defp get_proofs(nil), do: []
+  defp get_proofs(nil, page, size), do: []
 
   defp get_proofs(address, page, size) do
     proofs = ZkArcade.Proofs.get_proofs_by_address(address, %{page: page, page_size: size})

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -165,10 +165,6 @@ defmodule ZkArcadeWeb.ProofController do
             |> halt()
 
           proof ->
-            Logger.info(
-              "Found proof with ID #{proof_id}, verification data: #{inspect(proof.verification_data)}"
-            )
-
             case EIP712Verifier.verify_aligned_signature(
                   submit_proof_message,
                   address,
@@ -186,7 +182,6 @@ defmodule ZkArcadeWeb.ProofController do
                     Logger.error("No running task found for proof #{proof.id}")
                 end
 
-                Logger.info("Updating proof status to retry for proof ID: #{inspect(proof)}")
                 case Proofs.update_proof_retry(proof.id) do
                   {:ok, _} ->
                     Logger.info("Proof #{proof.id} updated before retrying")
@@ -194,8 +189,6 @@ defmodule ZkArcadeWeb.ProofController do
                   {:error, changeset} ->
                     Logger.error("Failed to update proof #{proof.id} status: #{inspect(changeset)}")
                 end
-
-                Logger.info("Updated proof status to retry for proof ID: #{inspect(proof)}")
 
                 task =
                   Task.Supervisor.async_nolink(ZkArcade.TaskSupervisor, fn ->

--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -186,6 +186,15 @@ defmodule ZkArcadeWeb.ProofController do
                     Logger.error("No running task found for proof #{proof.id}")
                 end
 
+                Logger.info("Updating proof status to retry for proof ID: #{inspect(proof)}")
+                case Proofs.update_proof_retry(proof.id) do
+                  {:ok, _} ->
+                    Logger.info("Proof #{proof.id} updated before retrying")
+
+                  {:error, changeset} ->
+                    Logger.error("Failed to update proof #{proof.id} status: #{inspect(changeset)}")
+                end
+
                 Logger.info("Updated proof status to retry for proof ID: #{inspect(proof)}")
 
                 task =

--- a/web/priv/repo/migrations/20250708155806_create_proofs.exs
+++ b/web/priv/repo/migrations/20250708155806_create_proofs.exs
@@ -10,6 +10,7 @@ defmodule ZkArcade.Repo.Migrations.CreateProofs do
       add :wallet_address, references(:wallets, column: :address, type: :string), null: false
       add :game, :string, null: false, default: "beast"
       add :proving_system, :string, null: false, default: "risc0"
+      add :times_retried, :integer, default: 0
 
       timestamps()
     end


### PR DESCRIPTION
This PR:
- Updates the `inserted_at` timestamp after a proof submission retry.
- Introduces a retry counter to track how many times the user has attempted to resubmit the proof.
- Fixes the proof signing by the user on submission retries.