### PR TITLE
feat: save username in database

### DIFF
--- a/web/lib/zk_arcade/accounts.ex
+++ b/web/lib/zk_arcade/accounts.ex
@@ -59,10 +59,10 @@ defmodule ZkArcade.Accounts do
   end
 
   def create_random_name do
-    names_seed_list_1 = ["Decentralized", "Trustless", "Permissionless", "Immutable", "Transparent", "Secure", "Scalable", "Efficient", "Encrypted", "Auditable", "Interoperable", "Deterministic", "Resilient", "Succinct", "Verifiable", "Private", "Compact", "Efficient", "Anonymous", "Zk", "Transparent", "Updatable", "Robust", "Distributed", "Programmable", "Tokenized", "Decentralized", "scalable", "modular", "asynchronous", "deterministic", "parallel", "distributed", "dynamic", "stateless", "typed", "compiled", "interpreted", "declarative", "functional", "immutable", "portable", "lightweight", "robust", "secure", "encrypted", "authenticated", "reliable", "responsive", "efficient", "optimized", "resilient", "redundant", "extensible", "maintainable", "performant", "Optimistic"]
-    names_seed_list_2 = ["lion", "tiger", "eagle", "wolf", "falcon", "bear", "fox", "owl", "panther", "shark", "whale", "snake", "rhino", "leopard", "jaguar", "bull", "antelope", "hawk", "cheetah", "lynx", "cougar", "crocodile", "buffalo", "scorpion", "lizard", "viper", "horse", "deer", "bison", "gorilla", "chimpanzee", "orangutan", "panda", "koala", "kangaroo", "dolphin", "octopus", "squid", "starfish", "seahorse", "jellyfish", "crab", "lobster", "shrimp", "anemone", "coral"]
+    adjectives = ["Homomorphic", "Elliptic", "ZKSnarky", "Snarky", "Plonkish", "Recursive", "Succinct", "NonInteractive", "Interactive", "Merkleized", "CommitmentBased", "VerifierFriendly", "ProofCarrying", "Polynomial", "TranscriptSafe", "Poseidonic", "HashBased", "GrothFriendly", "Bulletproofed", "Immutable", "CensorshipResistant", "Permissionless", "Byzantine", "Trustless", "SybilResistant", "Deterministic", "GasEfficient", "Composable", "EVMCompatible", "Layered", "RollupNative", "Bridgeable", "Optimistic", "Finalized", "Verifiable", "Algebraic", "Linear", "Modular", "Elliptic", "Isomorphic", "Prime", "Discrete", "Finite", "Bijective", "Injective", "Surjective", "Monoidal", "Canonical", "Fractal", "Probabilistic", "Geometric", "Affine", "Spectral", "Topological"]
+    animals = ["Tiger", "Fox", "Panda", "Lynx", "Wolf", "Owl", "Eagle", "Shark", "Panther", "Koala", "Cobra", "Falcon", "Rabbit", "Turtle", "Jaguar", "Bear", "Leopard", "Chameleon", "Penguin", "Sloth", "Dolphin", "Octopus", "Crab", "Lizard", "Scorpion", "Hawk", "Cheetah", "Rhino", "Buffalo", "Antelope", "Gorilla", "Chimpanzee", "Orangutan", "Bison", "Giraffe", "Kangaroo"]
 
-    Enum.random(names_seed_list_1) <> " " <> Enum.random(names_seed_list_2)
+    Enum.random(adjectives) <> Enum.random(animals)
   end
 
   @doc """

--- a/web/lib/zk_arcade/accounts.ex
+++ b/web/lib/zk_arcade/accounts.ex
@@ -58,6 +58,13 @@ defmodule ZkArcade.Accounts do
     end
   end
 
+  def create_random_name do
+    names_seed_list_1 = ["Decentralized", "Trustless", "Permissionless", "Immutable", "Transparent", "Secure", "Scalable", "Efficient", "Encrypted", "Auditable", "Interoperable", "Deterministic", "Resilient", "Succinct", "Verifiable", "Private", "Compact", "Efficient", "Anonymous", "Zk", "Transparent", "Updatable", "Robust", "Distributed", "Programmable", "Tokenized", "Decentralized", "scalable", "modular", "asynchronous", "deterministic", "parallel", "distributed", "dynamic", "stateless", "typed", "compiled", "interpreted", "declarative", "functional", "immutable", "portable", "lightweight", "robust", "secure", "encrypted", "authenticated", "reliable", "responsive", "efficient", "optimized", "resilient", "redundant", "extensible", "maintainable", "performant", "Optimistic"]
+    names_seed_list_2 = ["lion", "tiger", "eagle", "wolf", "falcon", "bear", "fox", "owl", "panther", "shark", "whale", "snake", "rhino", "leopard", "jaguar", "bull", "antelope", "hawk", "cheetah", "lynx", "cougar", "crocodile", "buffalo", "scorpion", "lizard", "viper", "horse", "deer", "bison", "gorilla", "chimpanzee", "orangutan", "panda", "koala", "kangaroo", "dolphin", "octopus", "squid", "starfish", "seahorse", "jellyfish", "crab", "lobster", "shrimp", "anemone", "coral"]
+
+    Enum.random(names_seed_list_1) <> " " <> Enum.random(names_seed_list_2)
+  end
+
   @doc """
   Creates a wallet.
 
@@ -71,6 +78,9 @@ defmodule ZkArcade.Accounts do
 
   """
   def create_wallet(attrs \\ %{}) do
+    username = create_random_name()
+    attrs = attrs |> Map.put_new(:username, username)
+
     %Wallet{}
     |> Wallet.changeset(attrs)
     |> Repo.insert()

--- a/web/lib/zk_arcade/accounts.ex
+++ b/web/lib/zk_arcade/accounts.ex
@@ -114,4 +114,24 @@ defmodule ZkArcade.Accounts do
   def change_wallet(%Wallet{} = wallet, attrs \\ %{}) do
     Wallet.changeset(wallet, attrs)
   end
+
+  def get_wallet_username(address) do
+    case fetch_wallet_by_address(address) do
+      {:ok, wallet} -> wallet.username
+      {:error, :not_found} -> nil
+    end
+  end
+
+  def set_wallet_username(address, username) do
+    case fetch_wallet_by_address(address) do
+      {:ok, wallet} ->
+        changeset = Wallet.changeset(wallet, %{username: username})
+        case Repo.update(changeset) do
+          {:ok, updated_wallet} -> {:ok, updated_wallet}
+          {:error, changeset} -> {:error, changeset}
+        end
+
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
 end

--- a/web/lib/zk_arcade/accounts/wallet.ex
+++ b/web/lib/zk_arcade/accounts/wallet.ex
@@ -9,6 +9,7 @@ defmodule ZkArcade.Accounts.Wallet do
     field :points, :integer, default: 0
     field :balance, :float, default: 0.0
     field :agreement_signature, :string
+    field :username, :string
     # TODO: Add the required fields to use in wallets
 
     has_many :proofs, ZkArcade.Proofs.Proof, foreign_key: :wallet_address, references: :address
@@ -19,7 +20,7 @@ defmodule ZkArcade.Accounts.Wallet do
   @doc false
   def changeset(wallet, attrs) do
     wallet
-    |> cast(attrs, [:address, :points, :balance, :agreement_signature])
+    |> cast(attrs, [:address, :points, :balance, :agreement_signature, :username])
     |> validate_address()
     |> validate_required([:address, :agreement_signature])
     |> put_default(:points, 0)

--- a/web/priv/repo/migrations/20241218184947_create_wallets.exs
+++ b/web/priv/repo/migrations/20241218184947_create_wallets.exs
@@ -8,6 +8,7 @@ defmodule ZkArcade.Repo.Migrations.CreateWallets do
       add :points, :integer, default: 0, null: false
       add :balance, :float, default: 0.0, null: false
       add :agreement_signature, :string
+      add :username, :string, null: false
 
       timestamps()
     end


### PR DESCRIPTION
This PR adds a username field to the Wallet Database schema and generates a random username when a wallet is created. It also adds endpoints to the DB to get or set the username.