### PR TITLE
feat: add a spinner animation on loading after proof submission

### DIFF
--- a/web/assets/js/react/modules/SubmitProof/SubmitProofBeast.tsx
+++ b/web/assets/js/react/modules/SubmitProof/SubmitProofBeast.tsx
@@ -382,6 +382,26 @@ export default ({
 					</div>
 				</Modal>
 			</div>
+
+			{submissionIsLoading && (
+				<div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black bg-opacity-70 text-white gap-8">
+					<svg
+						className="w-16 h-16 animate-spin-slow text-accent-100"
+						viewBox="0 0 50 50"
+					>
+						<circle
+							cx="25"
+							cy="25"
+							r="20"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="6"
+							strokeLinecap="round"
+							strokeDasharray="45 195"
+						/>
+					</svg>
+				</div>
+			)}
 		</>
 	);
 };

--- a/web/assets/tailwind.config.js
+++ b/web/assets/tailwind.config.js
@@ -84,6 +84,9 @@ module.exports = {
 			maxWidth: {
 				280: "280px",
 			},
+			animation: {
+				'spin-slow': 'spin 1.5s linear infinite',
+			},
 		},
 	},
 	plugins: [


### PR DESCRIPTION
This PR adds a spinner animation after proof submission.

This feature can be tested by submitting one proof. After submission, the spinner should appear for the next 10 seconds, until the redirection.