### PR TITLE
fix(web): don't redirect links on commands

### DIFF
--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -44,6 +44,13 @@ body {
 	border-radius: 8px;
 }
 
+.code-block a {
+	pointer-events: none;
+	text-decoration: none;
+	color: inherit;
+	cursor: text;
+}
+
 a {
 	word-break: keep-all;
 }


### PR DESCRIPTION
This fixes the issue https://github.com/yetanotherco/zk_arcade/issues/117.

To test it, go to the `/game/beast` section, and you should see the link as code text, and you won't be able to click the link.