### PR TITLE
fix: handle timeout ipv6 connection

### DIFF
--- a/web/assets/js/react/modules/SubmitProof/SubmitProofBeast.tsx
+++ b/web/assets/js/react/modules/SubmitProof/SubmitProofBeast.tsx
@@ -358,9 +358,9 @@ export default ({
 						{nonceError && (
 							<p className="text-red text-sm text-center">
 								{nonceError.message == "WebSocket connection error" ? (
-									<span>Connection with Aligned failed, try to connect later.</span>
+									"Connection with Aligned failed, try to connect later."
 								) : (
-									<span>Error connecting with Aligned: {nonceError.message}</span>
+									"Error connecting with Aligned: {nonceError.message}"
 								)}
 							</p>
 						)}

--- a/web/assets/js/react/modules/SubmitProof/SubmitProofBeast.tsx
+++ b/web/assets/js/react/modules/SubmitProof/SubmitProofBeast.tsx
@@ -43,7 +43,7 @@ export default ({
 	const [maxFee, setMaxFee] = useState(BigInt(0));
 	const [depositAmount, setDepositAmount] = useState("");
 	const [showDepositSection, setShowDepositSection] = useState(false);
-	const { nonce, isLoading: nonceLoading } = useBatcherNonce(
+	const { nonce, isLoading: nonceLoading, error: nonceError } = useBatcherNonce(
 		batcher_url,
 		user_address
 	);
@@ -355,6 +355,15 @@ export default ({
 							</div>
 						)}
 
+						{nonceError && (
+							<p className="text-red text-sm text-center">
+								{nonceError.message == "WebSocket connection error" ? (
+									<span>Connection with Aligned failed, try to connect later.</span>
+								) : (
+									<span>Error connecting with Aligned: {nonceError.message}</span>
+								)}
+							</p>
+						)}
 						<div>
 							<Button
 								variant="text"


### PR DESCRIPTION
This PR addresses a timeout in the IPv6 connection that was not handled, resulting in the proof remaining in a pending status indefinitely.

To test it, you can upload a proof and throw down the batcher; now the proof should turn to the failed status instead of remaining in the pending one.