### PR TITLE
chore: add makefile entry copying levels from deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ beast_gen_levels:
 beast_build:
 	@cd games/beast/beast1984 && cargo build --release --bin beast --features holesky
 
+gen_and_deploy_devnet: beast_gen_levels
+	@jq ".games = $$(jq '.games' games/beast/levels/leaderboard_devnet.json)" \
+		contracts/script/deploy/config/devnet/leaderboard.json \
+		> tmp.$$.json && mv tmp.$$.json contracts/script/deploy/config/devnet/leaderboard.json
+	@$(MAKE) deploy_contract NETWORK=devnet
+
 __CONTRACTS__:
 deploy_contract: submodules
 	@. contracts/scripts/.$(NETWORK).env && . contracts/scripts/deploy_contract.sh


### PR DESCRIPTION
This PR adds a makefile entry that:
- Generate the new levels
- Copies the games array from games/beast/levels/leaderboard_devnet.json and pastes it into the games attribute of the JSON in contracts/script/deploy/config/devnet/leaderboard.json
- Deploys the leaderboard contract with those levels
- Copies the deployed proxy address to the dev.exs file.

Note: The makefile target uses sed, which makes it available only in macOS, but since it's only for testing purposes, there's no trouble with it.

## How to test

1. Run aligned locally:
  i. Start the anvil node with `make anvil_start`
  ii. Start aggregator with `make aggregator_start ENVIRONMENT=devnet`
  iii. Start operator with `make operator_full_registration_and_start ENVIRONMENT=devnet`
  iv. Start the batcher with `make batcher_start_local ENVIRONMENT=devnet`
  v. Fund your account on anvil using cast send from a rich account: 
  `cast send <address> --value 10ether --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-url [http://localhost:8545/](http://localhost:8545/)`

Now you should run the makefile entry with `make gen_and_deploy_devnet`, and then you should be able to run the web without problems.