### PR TITLE
fix(web): explain that money must be deposited into aligned in the how to play section

### DIFF
--- a/web/lib/zk_arcade_web/controllers/html/home.html.heex
+++ b/web/lib/zk_arcade_web/controllers/html/home.html.heex
@@ -94,7 +94,7 @@
           show_line="true" 
           number="2" 
           title="Play & Prove" 
-          desc="Pick a game and complete the periodic challenges." 
+          desc="Pick a game and complete daily challenges." 
         />
         <div class="w-full h-[0.2px] bg-accent-100 hidden sm:block"></div>
         <.step_component 

--- a/web/lib/zk_arcade_web/controllers/page_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/page_controller.ex
@@ -134,9 +134,9 @@ defmodule ZkArcadeWeb.PageController do
         2. Install Beast with the following command: <span class="code-block">curl -L https://raw.githubusercontent.com/yetanotherco/zk_arcade/main/install_beast.sh | bash</span>
         3. Run the game with the command: <span class="code-block">beast</span>
         4. Locate the generated proof file on your system
-        5. Deposit into <span class="text-accent-100">ALIGNED</span> in case you don't have funds
+        5. Deposit into <span class="text-accent-100">ALIGNED</span> to pay the proof verification
         6. Upload your proof to verify your gameplay
-        7. After the proof is verified on <span class="text-accent-100">ALIGNED</span>, come back later to submit it to the leaderboard contract to earn points.
+        7. After the proof is verified on <span class="text-accent-100">ALIGNED</span>, come back to submit it to the Leaderboard to earn points.
 
         Important notes about proof submissions:
 


### PR DESCRIPTION
This PR adds a step that explains to users that they must deposit into Aligned if they do not have funds.