### PR TITLE
fix(web): Remove fee bumping for submitted proofs in Submission modal

### DIFF
--- a/web/assets/js/react/components/Modal/SubmitProof/SubmitStep.tsx
+++ b/web/assets/js/react/components/Modal/SubmitProof/SubmitStep.tsx
@@ -493,7 +493,7 @@ export const SubmitProofStep = ({
 					</div>
 				)}
 
-				{!bumpFeeOpen && (
+				{(!bumpFeeOpen && proofStatus !== "submitted") && (
 					<Button
 						className=""
 						variant="text-accent"


### PR DESCRIPTION
With this fix, you should not be able to resend the proof to the batcher with a higher fee once the batcher has added the sent one to a batch for its verification.