### PR TITLE
fix(web): don't show history menu if user is disconnected

### DIFF
--- a/web/assets/js/react/hooks/useProofSentMessageReader.ts
+++ b/web/assets/js/react/hooks/useProofSentMessageReader.ts
@@ -24,6 +24,14 @@ export const useProofSentMessageReader = () => {
 			});
 		}
 
+		if (message == "user-not-connected") {
+			addToast({
+				title: "User not connected",
+				desc: "You must be connected to a wallet to view your profile.",
+				type: "error",
+			});
+		}
+
 		// Remove the message param from the URL without reloading the page
 		// this prevents showing the message again when the user refreshes the page
 		if (message) {

--- a/web/lib/zk_arcade_web/controllers/page_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/page_controller.ex
@@ -57,6 +57,24 @@ defmodule ZkArcadeWeb.PageController do
     {proofs, beast_submissions_json}
   end
 
+  defp build_redirect_url(conn, message) do
+    referer = get_req_header(conn, "referer") |> List.first() || "/"
+    uri = URI.parse(referer)
+
+    query_params =
+      case uri.query do
+        nil -> %{}
+        q -> URI.decode_query(q)
+      end
+
+    new_query =
+      query_params
+      |> Map.put("message", message)
+      |> URI.encode_query()
+
+    uri.path <> "?" <> new_query
+  end
+
   def home(conn, _params) do
     leaderboard = ZkArcade.LeaderboardContract.top10()
     wallet = get_wallet_from_session(conn)
@@ -277,27 +295,30 @@ The goal of the game is to make each number on the board equal.
   end
 
   def history(conn, _params) do
-    wallet = get_wallet_from_session(conn)
-    {proofs, beast_submissions_json} = get_proofs_and_submissions(wallet, 1, 10)
+    case get_wallet_from_session(conn) do
+      nil -> conn |> redirect(to: build_redirect_url(conn, "user-not-connected"))
+      wallet ->
+        {proofs, beast_submissions_json} = get_proofs_and_submissions(wallet, 1, 10)
 
-    {username, position} = get_username_and_position(wallet)
+      {username, position} = get_username_and_position(wallet)
 
-    explorer_url = Application.get_env(:zk_arcade, :explorer_url)
-    batcher_url = Application.get_env(:zk_arcade, :batcher_url)
+      explorer_url = Application.get_env(:zk_arcade, :explorer_url)
+      batcher_url = Application.get_env(:zk_arcade, :batcher_url)
 
-    conn
-    |> assign(:wallet, wallet)
-    |> assign(:network, Application.get_env(:zk_arcade, :network))
-    |> assign(:proofs_sent_total, length(proofs))
-    |> assign(:submitted_proofs, Jason.encode!(proofs))
-    |> assign(:beast_submissions, beast_submissions_json)
-    |> assign(:leaderboard_address, Application.get_env(:zk_arcade, :leaderboard_address))
-    |> assign(:payment_service_address, Application.get_env(:zk_arcade, :payment_service_address))
-    |> assign(:username, username)
-    |> assign(:user_position, position)
-    |> assign(:explorer_url, explorer_url)
-    |> assign(:batcher_url, batcher_url)
-    |> render(:history)
+      conn
+      |> assign(:wallet, wallet)
+      |> assign(:network, Application.get_env(:zk_arcade, :network))
+      |> assign(:proofs_sent_total, length(proofs))
+      |> assign(:submitted_proofs, Jason.encode!(proofs))
+      |> assign(:beast_submissions, beast_submissions_json)
+      |> assign(:leaderboard_address, Application.get_env(:zk_arcade, :leaderboard_address))
+      |> assign(:payment_service_address, Application.get_env(:zk_arcade, :payment_service_address))
+      |> assign(:username, username)
+      |> assign(:user_position, position)
+      |> assign(:explorer_url, explorer_url)
+      |> assign(:batcher_url, batcher_url)
+      |> render(:history)
+    end
   end
 
   def leaderboard(conn, params) do


### PR DESCRIPTION
## How to test
1. If you are connected, disconnect your wallet
2. Go to the Profile menu of the nav bar
3. You should see an error message, and stay on the previous page.