### PR TITLE
feat(web): add pagination control to the history

### DIFF
--- a/web/assets/js/react/modules/History/ProofHistory.tsx
+++ b/web/assets/js/react/modules/History/ProofHistory.tsx
@@ -43,6 +43,8 @@ const Entry = ({
 }) => {
 	const { open, setOpen, toggleOpen } = useModal();
 
+	const levelsNumber = proof.game === "Beast" ? 8 : 3;
+
 	return (
 		<>
 			<tr
@@ -55,7 +57,7 @@ const Entry = ({
 						className="group/tooltip flex flex-row gap-0.5 items-center"
 						style={{ maxWidth: 50 }}
 					>
-						{[...Array(8)].map((_, index) => {
+						{[...Array(levelsNumber)].map((_, index) => {
 							return (
 								<div
 									key={index}
@@ -63,7 +65,7 @@ const Entry = ({
 									w-full h-[10px] mb-2
 									${index < proof.level_reached ? "bg-accent-100" : "bg-contrast-100"}
 									${index === 0 ? "rounded-l-[3px]" : ""}
-									${index === 7 ? "rounded-r-[3px]" : ""}
+									${index === levelsNumber - 1 ? "rounded-r-[3px]" : ""}
 									`}
 								></div>
 							);

--- a/web/lib/zk_arcade/proofs.ex
+++ b/web/lib/zk_arcade/proofs.ex
@@ -113,6 +113,13 @@ defmodule ZkArcade.Proofs do
       end)
   end
 
+  def get_total_proofs_by_address(nil), do: 0
+  def get_total_proofs_by_address(address) do
+    downcased_addr = String.downcase(address)
+    from(p in Proof, where: p.wallet_address == ^downcased_addr)
+    |> Repo.aggregate(:count, :id)
+  end
+
   def get_proof_submission(proof_id) do
     query =
       from p in Proof,
@@ -163,7 +170,6 @@ defmodule ZkArcade.Proofs do
       })
       |> Repo.one()
   end
-
 
   def get_proof_verification_data(proof_id) do
     Proof

--- a/web/lib/zk_arcade_web/components/core_components.ex
+++ b/web/lib/zk_arcade_web/components/core_components.ex
@@ -633,12 +633,12 @@ defmodule ZkArcadeWeb.CoreComponents do
   end
 
   attr :pagination, :map, required: true
-  attr :items_per_page, :integer, default: 10
+  attr :paginated_item_name, :string, default: "users"
   def pagination_info(assigns) do
     ~H"""
     <div class="text-center mt-4 text-text-200">
-      Showing <%= (@pagination.current_page - 1) * @items_per_page + 1 %>-<%= min(@pagination.current_page * @items_per_page, @pagination.total_users) %>
-      of <%= @pagination.total_users %> users
+      Showing <%= (@pagination.current_page - 1) * @pagination.items_per_page + 1 %>-<%= min(@pagination.current_page * @pagination.items_per_page, @pagination.total_users) %>
+      of <%= @pagination.total_users %> <%= @paginated_item_name %>
     </div>
     """
   end

--- a/web/lib/zk_arcade_web/components/core_components.ex
+++ b/web/lib/zk_arcade_web/components/core_components.ex
@@ -711,7 +711,7 @@ defmodule ZkArcadeWeb.CoreComponents do
   def history_section(assigns) do
     ~H"""
       <%= if @show_pagination && @pagination do %>
-        <div class="mt-8">
+        <div>
           <.pagination_controls pagination={@pagination} base_path="/history" />
           <.pagination_info pagination={@pagination} paginated_item_name={"proofs"} />
         </div>

--- a/web/lib/zk_arcade_web/components/core_components.ex
+++ b/web/lib/zk_arcade_web/components/core_components.ex
@@ -588,14 +588,14 @@ defmodule ZkArcadeWeb.CoreComponents do
     ~H"""
     <div class="flex gap-x-2 items-center justify-center min-w-full">
       <%= if @pagination.current_page >= 2 do %>
-        <.link href={"/leaderboard?page=#{1}"}>
+        <.link href={"#{@base_path}?page=#{1}"}>
           <.button>
             First
           </.button>
         </.link>
       <% end %>
       <%= if @pagination.current_page > 1 do %>
-        <.link href={"/leaderboard?page=#{@pagination.current_page - 1}"}>
+        <.link href={"#{@base_path}?page=#{@pagination.current_page - 1}"}>
           <.button>
             <.icon
               name="hero-arrow-left-solid"
@@ -614,7 +614,7 @@ defmodule ZkArcadeWeb.CoreComponents do
         />
       </form>
       <%= if @pagination.current_page != @pagination.total_pages do %>
-        <.link href={"/leaderboard?page=#{@pagination.current_page + 1}"}>
+        <.link href={"#{@base_path}?page=#{@pagination.current_page + 1}"}>
           <.button>
             <.icon
               name="hero-arrow-right-solid"
@@ -622,7 +622,7 @@ defmodule ZkArcadeWeb.CoreComponents do
             />
           </.button>
         </.link>
-        <.link href={"/leaderboard?page=#{@pagination.total_pages}"}>
+        <.link href={"#{@base_path}?page=#{@pagination.total_pages}"}>
           <.button>
             Last
           </.button>

--- a/web/lib/zk_arcade_web/components/core_components.ex
+++ b/web/lib/zk_arcade_web/components/core_components.ex
@@ -706,6 +706,19 @@ defmodule ZkArcadeWeb.CoreComponents do
     """
   end
 
+  attr :pagination, :map, default: nil
+  attr :show_pagination, :boolean, default: false
+  def history_section(assigns) do
+    ~H"""
+      <%= if @show_pagination && @pagination do %>
+        <div class="mt-8">
+          <.pagination_controls pagination={@pagination} base_path="/history" />
+          <.pagination_info pagination={@pagination} paginated_item_name={"proofs"} />
+        </div>
+      <% end %>
+    """
+  end
+
   attr :users, :list, required: true
   attr :current_wallet, :string, default: nil
   attr :user_data, :map, default: nil

--- a/web/lib/zk_arcade_web/controllers/html/history.html.heex
+++ b/web/lib/zk_arcade_web/controllers/html/history.html.heex
@@ -52,6 +52,11 @@
                 explorer_url={@explorer_url}
                 batcher_url={@batcher_url}
             />
+
+            <.history_section 
+                pagination={@pagination}
+                show_pagination={true}
+            />
         </div>
     </div>
 

--- a/web/lib/zk_arcade_web/controllers/page_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/page_controller.ex
@@ -284,7 +284,7 @@ The goal of the game is to make each number on the board equal.
     page = String.to_integer(params["page"] || "1")
     offset = (page - 1) * entries_per_page
 
-    total_proofs = length(ZkArcade.Proofs.get_proofs_by_address(wallet, %{page: 1, page_size: 100}))
+    total_proofs = ZkArcade.Proofs.get_total_proofs_by_address(wallet)
 
     total_pages = ceil(total_proofs / entries_per_page)
     has_prev = page > 1

--- a/web/lib/zk_arcade_web/controllers/page_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/page_controller.ex
@@ -313,32 +313,32 @@ The goal of the game is to make each number on the board equal.
 
         {proofs, beast_submissions_json} = get_proofs_and_submissions(wallet, page, entries_per_page)
 
-      {username, position} = get_username_and_position(wallet)
+        {username, position} = get_username_and_position(wallet)
 
-      explorer_url = Application.get_env(:zk_arcade, :explorer_url)
-      batcher_url = Application.get_env(:zk_arcade, :batcher_url)
+        explorer_url = Application.get_env(:zk_arcade, :explorer_url)
+        batcher_url = Application.get_env(:zk_arcade, :batcher_url)
 
-      conn
-      |> assign(:wallet, wallet)
-      |> assign(:network, Application.get_env(:zk_arcade, :network))
-      |> assign(:proofs_sent_total, length(proofs))
-      |> assign(:submitted_proofs, Jason.encode!(proofs))
-      |> assign(:beast_submissions, beast_submissions_json)
-      |> assign(:leaderboard_address, Application.get_env(:zk_arcade, :leaderboard_address))
-      |> assign(:payment_service_address, Application.get_env(:zk_arcade, :payment_service_address))
-      |> assign(:username, username)
-      |> assign(:user_position, position)
-      |> assign(:explorer_url, explorer_url)
-      |> assign(:batcher_url, batcher_url)
-      |> assign(:pagination, %{
-        current_page: page,
-        total_pages: total_pages,
-        has_prev: has_prev,
-        has_next: has_next,
-        total_users: total_proofs,
-        items_per_page: entries_per_page
-      })
-      |> render(:history)
+        conn
+        |> assign(:wallet, wallet)
+        |> assign(:network, Application.get_env(:zk_arcade, :network))
+        |> assign(:proofs_sent_total, length(proofs))
+        |> assign(:submitted_proofs, Jason.encode!(proofs))
+        |> assign(:beast_submissions, beast_submissions_json)
+        |> assign(:leaderboard_address, Application.get_env(:zk_arcade, :leaderboard_address))
+        |> assign(:payment_service_address, Application.get_env(:zk_arcade, :payment_service_address))
+        |> assign(:username, username)
+        |> assign(:user_position, position)
+        |> assign(:explorer_url, explorer_url)
+        |> assign(:batcher_url, batcher_url)
+        |> assign(:pagination, %{
+          current_page: page,
+          total_pages: total_pages,
+          has_prev: has_prev,
+          has_next: has_next,
+          total_users: total_proofs,
+          items_per_page: entries_per_page
+        })
+        |> render(:history)
     end
   end
 


### PR DESCRIPTION
This PR adds pagination control to the proofs list on the Profile menu (the pagination logic was already developed). It also fixes the progress bar for the Parity games (by showing only 3 levels in the bar instead of 8).