### PR TITLE
fix: parity games decoding

### DIFF
--- a/web/assets/js/react/modules/Parity/useParityGames.ts
+++ b/web/assets/js/react/modules/Parity/useParityGames.ts
@@ -29,11 +29,13 @@ export const useParityGames = ({
 
 	const levels: ParityLevel[] = useMemo(() => {
 		if (!gameConfig) return [];
-		let gameConfigBytes = toBytes(gameConfig);
+		let gameConfigBytes = toBytes(gameConfig, { size: 32 });
 		let levels: ParityLevel[] = [];
 
-		for (let i = 0; i < gameConfigBytes.length / 10; i++) {
-			let byte_idx = i * 10;
+		// we substract 2 because the gameConfig only takes 30 bytes (each level takes 10 bytes and there is three per gameConfig)
+		for (let i = 0; i < (gameConfigBytes.length - 2) / 10; i++) {
+			// ignore the first two bytes
+			let byte_idx = i * 10 + 2;
 			let initialPos: ParityLevel["initialPos"] = {
 				col: gameConfigBytes[byte_idx] >> 4,
 				row: gameConfigBytes[byte_idx] & 0x0f,


### PR DESCRIPTION
**Description**
Fixes the decoding of parity games initial position. The bug would happen when the initial position was x: 0 and y: 0. When converting the string to bytes, we were ignoring the zeros. Now when converting the string to bytes we use 32 bytes even if they are zero.