### PR TITLE
fix(web): allow user to play again on proof generation failure

### DIFF
--- a/web/assets/js/react/modules/Parity/Game.tsx
+++ b/web/assets/js/react/modules/Parity/Game.tsx
@@ -205,6 +205,7 @@ export const Game = ({
 				timeRemaining={timeRemaining}
 				nft_contract_address={nft_contract_address}
 				gameIdx={currentGameIdx}
+				setPlayerLevelReached={setPlayerLevelReached}
 			/>
 		),
 	};

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -122,6 +122,27 @@ export const ProveAndSubmit = ({
 		);
 	}
 
+	const proofGenerationErrorView: JSX.Element = (
+		<>
+			<div className="bg-red/20 text-red border border-red text-center p-2 rounded mb-2 max-w-[500px]">
+				There was an error generating your proof.
+				Please try playing and generating your proof again.
+			</div>
+
+			<div className="flex flex-col gap-5 w-full max-w-[300px]">
+				<Button
+					variant="arcade"
+					className="w-full"
+					onClick={() => {
+						setGameState("home");
+					}}
+				>
+					Home
+				</Button>
+			</div>
+		</>
+	);
+
 	return (
 		<div>
 			<div className="w-full h-full flex flex-col gap-4 items-center max-w-[500px]">
@@ -138,24 +159,7 @@ export const ProveAndSubmit = ({
 					</div>
 
 						{proofGenerationFailed ? (
-							<>
-								<div className="bg-red/20 text-red border border-red text-center p-2 rounded mb-2 max-w-[500px]">
-									There was an error generating your proof.
-									Please try playing and generating your proof again.
-								</div>
-
-								<div className="flex flex-col gap-5 w-full max-w-[300px]">
-									<Button
-										variant="arcade"
-										className="w-full"
-										onClick={() => {
-											setGameState("home");
-										}}
-									>
-										Home
-									</Button>
-								</div>
-							</>
+							proofGenerationErrorView
 						) : (
 							<>
 								<div className="w-full max-w-[500px] space-y-2">

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -91,7 +91,7 @@ export const ProveAndSubmit = ({
 			}
 
 			// Restore the level reached by the user to the last one submitted on-chain
-			setPlayerLevelReached(submittedLevelOnChain == 0 ? 1 : submittedLevelOnChain);
+			setPlayerLevelReached(submittedLevelOnChain + 1);
 		}
 	};
 

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -137,66 +137,89 @@ export const ProveAndSubmit = ({
 						</p>
 					</div>
 
-					<div className="w-full max-w-[500px] space-y-2">
-						{currentLevel === 0 && (
-							<div className="bg-red/20 text-red border border-red text-center p-2 rounded">
-								You haven’t completed any levels yet. There’s
-								nothing to generate.
-							</div>
-						)}
-
-						{alreadySubmittedUpToOrBeyond && !hasSubmittedThree && (
-							<div className="bg-red/20 text-red border border-red text-center p-2 rounded">
-								You have already submitted a proof up to level{" "}
-								{submittedLevelOnChain} on-chain. Complete at
-								least one more level before submitting again.
-							</div>
-						)}
-
-						{currentLevel > 0 &&
-							currentLevel < 3 &&
-							!alreadySubmittedUpToOrBeyond &&
-							!hasSubmittedThree && (
-								<div className="bg-yellow/20 text-yellow border border-yellow text-center p-2 rounded">
-									The full game wasn’t completed — you are
-									missing {3 - currentLevel}{" "}
-									{3 - currentLevel === 1
-										? "level"
-										: "levels"}
-									. If you submit a proof now, you’ll need to
-									prove the remaining levels later.
+						{proofGenerationFailed ? (
+							<>
+								<div className="bg-red/20 text-red border border-red text-center p-2 rounded mb-2 max-w-[500px]">
+									There was an error generating your proof.
+									Please try playing and generating your proof again.
 								</div>
-							)}
 
-						{currentLevel === 3 && !hasSubmittedThree && (
-							<div className="bg-accent-100/20 text-accent-100 border border-accent-100 text-center p-2 rounded">
-								Great job! You’ve completed the game — generate
-								and submit your proof now.
-							</div>
+								<div className="flex flex-col gap-5 w-full max-w-[300px]">
+									<Button
+										variant="arcade"
+										className="w-full"
+										onClick={() => {
+											setGameState("home");
+										}}
+									>
+										Home
+									</Button>
+								</div>
+							</>
+						) : (
+							<>
+								<div className="w-full max-w-[500px] space-y-2">
+									{currentLevel === 0 && (
+										<div className="bg-red/20 text-red border border-red text-center p-2 rounded">
+											You haven’t completed any levels yet. There’s
+											nothing to generate.
+										</div>
+									)}
+
+									{alreadySubmittedUpToOrBeyond && !hasSubmittedThree && (
+										<div className="bg-red/20 text-red border border-red text-center p-2 rounded">
+											You have already submitted a proof up to level{" "}
+											{submittedLevelOnChain} on-chain. Complete at
+											least one more level before submitting again.
+										</div>
+									)}
+
+									{currentLevel > 0 &&
+										currentLevel < 3 &&
+										!alreadySubmittedUpToOrBeyond &&
+										!hasSubmittedThree && (
+											<div className="bg-yellow/20 text-yellow border border-yellow text-center p-2 rounded">
+												The full game wasn’t completed — you are
+												missing {3 - currentLevel}{" "}
+												{3 - currentLevel === 1
+													? "level"
+													: "levels"}
+												. If you submit a proof now, you’ll need to
+												prove the remaining levels later.
+											</div>
+										)}
+
+									{currentLevel === 3 && !hasSubmittedThree && (
+										<div className="bg-accent-100/20 text-accent-100 border border-accent-100 text-center p-2 rounded">
+											Great job! You’ve completed the game — generate
+											and submit your proof now.
+										</div>
+									)}
+								</div>
+
+								<div className="flex flex-col gap-5 w-full max-w-[300px]">
+									<Button
+										variant="arcade"
+										className="w-full"
+										onClick={() => {
+											generateproofVerificationData();
+										}}
+										disabled={disableGenerate}
+									>
+										Generate Proof
+									</Button>
+									<Button
+										variant="arcade"
+										className="w-full"
+										onClick={() => {
+											setGameState("home");
+										}}
+									>
+										Home
+									</Button>
+								</div>
+							</>
 						)}
-					</div>
-
-					<div className="flex flex-col gap-5 w-full max-w-[300px]">
-						<Button
-							variant="arcade"
-							className="w-full"
-							onClick={() => {
-								generateproofVerificationData();
-							}}
-							disabled={disableGenerate}
-						>
-							Generate Proof
-						</Button>
-						<Button
-							variant="arcade"
-							className="w-full"
-							onClick={() => {
-								setGameState("home");
-							}}
-						>
-							Home
-						</Button>
-					</div>
 				</div>
 			</div>
 

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -43,6 +43,8 @@ export const ProveAndSubmit = ({
 	const [proofVerificationData, setProofVerificationData] =
 		useState<VerificationData | null>(null);
 
+	const [proofGenerationFailed, setProofGenerationFailed] = useState(false);
+
 	const [userGameData, _setUserGameData] = useState<GameStatus>(() => {
 		const stored = localStorage.getItem("parity-game-data");
 		const gameData: { [key: string]: GameStatus } = stored
@@ -58,14 +60,19 @@ export const ProveAndSubmit = ({
 	});
 
 	const generateproofVerificationData = async () => {
-		const submitproofVerificationData = await generateCircomParityProof({
-			user_address,
-			userPositions: userGameData.userPositions,
-			levelsBoards: userGameData.levelsBoards,
-		});
+		try {
+			const submitproofVerificationData = await generateCircomParityProof({
+				user_address,
+				userPositions: userGameData.userPositions,
+				levelsBoards: userGameData.levelsBoards,
+			});
 
-		setProofVerificationData(submitproofVerificationData);
-		setOpen(true);
+			setProofVerificationData(submitproofVerificationData);
+			setOpen(true);
+		} catch (e) {
+			console.error("Error generating proof:", e);
+			setProofGenerationFailed(true);
+		}
 	};
 
 	const currentLevel = userGameData.levelsBoards.length;

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -91,7 +91,7 @@ export const ProveAndSubmit = ({
 			}
 
 			// Restore the level reached by the user to the last one submitted on-chain
-			setPlayerLevelReached(submittedLevelOnChain);
+			setPlayerLevelReached(submittedLevelOnChain == 0 ? 1 : submittedLevelOnChain);
 		}
 	};
 

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -72,6 +72,21 @@ export const ProveAndSubmit = ({
 		} catch (e) {
 			console.error("Error generating proof:", e);
 			setProofGenerationFailed(true);
+
+			// Delete the probably invalid levels from local storage (those that
+			// haven't been submitted on-chain yet)
+			const stored = localStorage.getItem("parity-game-data");
+			const gameData: { [key: string]: GameStatus } = stored
+				? JSON.parse(stored)
+				: {};
+			const key = gameDataKey(currentGameConfig, user_address);
+			if (gameData[key]) {
+				for (let i = submittedLevelOnChain + 1; i <= 3; i++) {
+					gameData[key].levelsBoards.pop();
+					gameData[key].userPositions.pop();
+				}
+				localStorage.setItem("parity-game-data", JSON.stringify(gameData));
+			}
 		}
 	};
 

--- a/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
+++ b/web/assets/js/react/modules/Parity/ProveAndSubmit.tsx
@@ -27,6 +27,7 @@ export const ProveAndSubmit = ({
 	timeRemaining,
 	nft_contract_address,
 	gameIdx,
+	setPlayerLevelReached,
 }: {
 	user_address: Address;
 	payment_service_address: Address;
@@ -38,6 +39,7 @@ export const ProveAndSubmit = ({
 	timeRemaining?: TimeRemaining | null;
 	nft_contract_address: Address;
 	gameIdx: number;
+	setPlayerLevelReached: (level: number) => void;
 }) => {
 	const [open, setOpen] = useState(false);
 	const [proofVerificationData, setProofVerificationData] =
@@ -87,6 +89,9 @@ export const ProveAndSubmit = ({
 				}
 				localStorage.setItem("parity-game-data", JSON.stringify(gameData));
 			}
+
+			// Restore the level reached by the user to the last one submitted on-chain
+			setPlayerLevelReached(submittedLevelOnChain);
 		}
 	};
 


### PR DESCRIPTION
If a Circom proof generation error occurs, a message is now shown to the user recommending that they play again and regenerate the proof.

## How to test
Play Parity level one, submit your response for that level, and claim your points. Then, erase the logic of filling the Circom proof inputs at the `web/assets/js/react/modules/Parity/GenerateProof.ts` file (lines 67 to 85). From now on, all proof generation should fail. Now, play levels 2 and 3, and try to generate the proof for solving those levels. You will find an error message, and after restoring the removed Circom code, you should play the levels again, starting from the second one.