### PR TITLE
fix: responsiveness for small screens in beast and parity

### DIFF
--- a/web/lib/zk_arcade_web/controllers/html/beast_game.html.heex
+++ b/web/lib/zk_arcade_web/controllers/html/beast_game.html.heex
@@ -23,7 +23,7 @@
              <%= for %{text: text, link: link} <- @game.acknowledgments do %>
              <div class="flex flex-row flex-wrap">
                 <p class="text-md mr-1 text-text-200"><%= text %>:</p>
-                <a href={link} class="text-md mb-1 text-blue hover:underline" target="_blank" rel="noopener noreferrer"><%= link %></a>
+                <a href={link} class="text-md mb-1 text-blue break-all hover:underline" target="_blank" rel="noopener noreferrer"><%= link %></a>
             </div>
             <% end %>
         </section>

--- a/web/lib/zk_arcade_web/controllers/html/parity_game.html.heex
+++ b/web/lib/zk_arcade_web/controllers/html/parity_game.html.heex
@@ -30,7 +30,7 @@
              <%= for %{text: text, link: link} <- @game.acknowledgments do %>
              <div class="flex flex-row flex-wrap">
                 <p class="text-md mr-1 text-text-200"><%= text %>:</p>
-                <a href={link} class="text-md mb-1 text-blue hover:underline" target="_blank" rel="noopener noreferrer"><%= link %></a>
+                <a href={link} class="text-md mb-1 text-blue break-all hover:underline" target="_blank" rel="noopener noreferrer"><%= link %></a>
             </div>
             <% end %>
         </section>


### PR DESCRIPTION
**Description**

In smalls screens, the acknowledgements links would overflow and lead to a bad ux 