### PR TITLE
fix(parity): avoid generating zero values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ PARITY_NUM_GAMES ?= 10
 PARITY_LEVELS_PER_GAME ?= 3
 # UI-only: lower bound for numbers shown at the end of a level on the board.
 # Does NOT affect difficulty or movement calculations.
-PARITY_MIN_END_OF_LEVEL ?= 8
+PARITY_MIN_END_OF_LEVEL ?= 12
 # UI-only: upper bound for numbers shown at the end of a level on the board.
 # Does NOT affect difficulty or movement calculations.
 PARITY_MAX_END_OF_LEVEL ?= 50

--- a/games/parity/level_generator/src/main.rs
+++ b/games/parity/level_generator/src/main.rs
@@ -122,43 +122,33 @@ fn gen_levels(
 
         let moves = calculate_movements_for_level(i, num_levels, min_movements, max_movements);
 
-        for j in 0..moves {
+        for mut j in 0..moves {
             let mut roll = -1;
 
             while !possible(roll, selected) {
                 roll = random_number_between(0, 4) as i16;
             }
 
-            match roll {
-                0 => {
-                    selected -= 3;
-                    solution.push(Movement::Down);
-                    if j + 1 != moves {
-                        board[selected as usize] = board[selected as usize].saturating_sub(1);
-                    }
-                }
-                1 => {
-                    selected += 3;
-                    solution.push(Movement::Up);
-                    if j + 1 != moves {
-                        board[selected as usize] = board[selected as usize].saturating_sub(1);
-                    }
-                }
-                2 => {
-                    selected -= 1;
-                    solution.push(Movement::Right);
-                    if j + 1 != moves {
-                        board[selected as usize] = board[selected as usize].saturating_sub(1);
-                    }
-                }
-                3 => {
-                    selected += 1;
-                    solution.push(Movement::Left);
-                    if j + 1 != moves {
-                        board[selected as usize] = board[selected as usize].saturating_sub(1);
-                    }
-                }
-                _ => {}
+            let (new_selected, new_movement) = match roll {
+                0 => (selected - 3, Movement::Down),
+                1 => (selected + 3, Movement::Up),
+                2 => (selected - 1, Movement::Right),
+                3 => (selected + 1, Movement::Left),
+                _ => (selected, Movement::Down),
+            };
+
+            // if the position is zero we cannot decrease it anymore, so we reroll
+            // Note: this could lead to infinite loops in some edge cases, but the probability is really low,
+            // and it's even lower when we increase the minimum end of level value.
+            if board[new_selected as usize] == 0 {
+                j -= 1;
+                continue;
+            }
+
+            selected = new_selected;
+            solution.push(new_movement);
+            if j + 1 != moves {
+                board[selected as usize] = board[selected as usize].saturating_sub(1);
             }
         }
 

--- a/games/parity/level_generator/src/main.rs
+++ b/games/parity/level_generator/src/main.rs
@@ -118,7 +118,7 @@ fn gen_levels(
 
         let mut selected = random_number_between(0, 9);
         let mut solution: Vec<Movement> = vec![];
-        board[selected as usize] = board[selected as usize].saturating_sub(1);
+        board[selected as usize] -= 1;
 
         let moves = calculate_movements_for_level(i, num_levels, min_movements, max_movements);
 
@@ -148,7 +148,7 @@ fn gen_levels(
             selected = new_selected;
             solution.push(new_movement);
             if j + 1 != moves {
-                board[selected as usize] = board[selected as usize].saturating_sub(1);
+                board[selected as usize] -= 1;
             }
         }
 


### PR DESCRIPTION
This PR made some changes to the parity levels generation:
- increases the parity end of level minimum from 8 to 12 to reduce the possibilities of reaching zero in a level.
- Simulates the level change to check if the cell to move is zero (in that case, it would generate an underflow), and rollbacks in that case.
- Removes the saturating subs, as it hides this underflow, generating invalid levels.