### PR TITLE
fix(web): proofs amount and table in history

### DIFF
--- a/web/assets/js/react/modules/History/ProofHistory.tsx
+++ b/web/assets/js/react/modules/History/ProofHistory.tsx
@@ -162,6 +162,8 @@ export const ProofHistory = ({
 					{ text: "Prover" },
 				]}
 			>
+                <hr className="border-text-200 w-full" style={{ minWidth: 1000 }} />
+
 				{proofs.map((proof, idx) => (
 					<Entry
 						key={idx}

--- a/web/lib/zk_arcade_web/controllers/html/history.html.heex
+++ b/web/lib/zk_arcade_web/controllers/html/history.html.heex
@@ -60,10 +60,12 @@
                 nft_contract_address={@nft_contract_address}
             />
 
-            <.history_section 
-                pagination={@pagination}
-                show_pagination={true}
-            />
+            <%= if @proofs_sent_total > 0 do %>
+                <.history_section 
+                    pagination={@pagination}
+                    show_pagination={true}
+                />
+            <% end %>
         </div>
     </div>
 

--- a/web/lib/zk_arcade_web/controllers/html/history.html.heex
+++ b/web/lib/zk_arcade_web/controllers/html/history.html.heex
@@ -65,6 +65,12 @@
                     pagination={@pagination}
                     show_pagination={true}
                 />
+            <% else %>
+                <div class="text-center">
+                    <p className="text-text-200 mt-10">
+                        You haven't submitted any proofs yet. Play a game and submit your first proof!
+                    </p>
+                </div>
             <% end %>
         </div>
     </div>

--- a/web/lib/zk_arcade_web/controllers/page_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/page_controller.ex
@@ -360,7 +360,7 @@ The goal of the game is to make each number on the board equal.
         |> assign(:wallet, wallet)
         |> assign(:eligible, eligible)
         |> assign(:network, Application.get_env(:zk_arcade, :network))
-        |> assign(:proofs_sent_total, length(proofs))
+        |> assign(:proofs_sent_total, total_proofs)
         |> assign(:submitted_proofs, Jason.encode!(proofs))
         |> assign(:beast_submissions, beast_submissions_json)
         |> assign(:leaderboard_address, Application.get_env(:zk_arcade, :leaderboard_address))


### PR DESCRIPTION
The changes should be seen in the user history:
- In case the user has not submitted any proofs, a message should appear saying that there are no proofs instead of pagination controls.
- The proofs amount now should be able to surpass the pagination limit (that was 5), so if you upload more than 5 proofs, you should see the correct number on the Proofs sent attribute.