### PR TITLE
fix: don't store proofs whose verification failed

### DIFF
--- a/web/lib/zk_arcade_web/controllers/proof_controller.ex
+++ b/web/lib/zk_arcade_web/controllers/proof_controller.ex
@@ -163,6 +163,9 @@ defmodule ZkArcadeWeb.ProofController do
 
               {:ok, {:error, reason}} ->
                 Logger.error("Failed to send proof to batcher: #{inspect(reason)}")
+                # Remove the proof since it failed during batcher validation,
+                # we don't want to count it as sent
+                Proofs.delete_proof(pending_proof)
 
                 conn
                 |> put_flash(:error, "Failed to submit proof: #{inspect(reason)}")


### PR DESCRIPTION
**Description**

Remove from the database those proofs that have failed during batcher validation (if there was an error message within the first 10 seconds)

**How to test**
To test it you can modify the batcher aligned to send an error message in the `handle_submit_proof_message`.
