### PR TITLE
fix(infra): use npm ci instead of install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ release:
 	mix local.rebar --force && \
 	mix deps.get --only $(MIX_ENV) && \
 	mix compile && \
-	npm --prefix assets install && \
+	npm --prefix assets ci && \
 	mix phx.digest && \
 	mix assets.deploy && \
 	mix release


### PR DESCRIPTION
Using ci instead of install, performs a clean install validating package.json and package-lock.json are the same and it does not perform any update on packages
It is a security measure

Closes #315