### PR TITLE
fix: bump stop loading on failure so the user can retry

### DIFF
--- a/web/assets/js/react/components/Modal/SubmitProof/SubmitStep.tsx
+++ b/web/assets/js/react/components/Modal/SubmitProof/SubmitStep.tsx
@@ -358,6 +358,7 @@ export const SubmitProofStep = ({
 				proofSubmission?.id || ""
 			);
 			if (!res) {
+				setBumpLoading(false);
 				addToast({
 					title: "There was a problem while sending the proof",
 					desc: "Please try again.",
@@ -396,6 +397,7 @@ export const SubmitProofStep = ({
 				formRetryRef.current?.submit();
 			}, 1000);
 		} catch (error) {
+			setBumpLoading(false);
 			addToast({
 				title: "Could not apply the bump",
 				desc: "Please try again in a few seconds.",
@@ -654,7 +656,8 @@ export const SubmitProofStep = ({
 						<p className="text-red">
 							You have already submitted a proof with a higher or
 							equal level for this game. If you uploaded the proof
-							recently, you'll have to wait 6 hours to submit it again.
+							recently, you'll have to wait 6 hours to submit it
+							again.
 						</p>
 					)}
 					{(balance.data || 0) < maxFee && (


### PR DESCRIPTION
**Description**

When bumping the proof, if it failed (for example if the user rejected to sign) the confirmation button would still be loading. This prs makes sure that if nothing was submitted then don't show the loader.