### PR TITLE
feat: handle proof replacement without marking the proof as failed

### DIFF
--- a/web/lib/zk_arcade/batcher_connection.ex
+++ b/web/lib/zk_arcade/batcher_connection.ex
@@ -131,7 +131,12 @@ defmodule ZkArcade.BatcherConnection do
       %{"InvalidProof" => reason} ->
         Logger.error("There was a problem with the submited proof: #{reason}")
         close_connection(conn_pid, stream_ref)
-        {:error, "Invalid proof - #{reason}"}
+        {:error, {:invalid_proof, reason}}
+
+      "ProofReplaced" ->
+        Logger.warning("Transaction replaced by higher fee")
+        close_connection(conn_pid, stream_ref)
+        {:error, :replaced_by_higher_fee}
 
       # There can be more error messages from the batcher, but they will enter on the other clause
       other ->
@@ -179,6 +184,10 @@ defmodule ZkArcade.BatcherConnection do
     :gun.ws_send(conn_pid, stream_ref, {:close, 1000, ""})
     receive do
       {:gun_ws, ^conn_pid, ^stream_ref, {:close, _code, _reason}} ->
+        :gun.close(conn_pid)
+    after
+      10_000 ->
+        Logger.warning("Close handshake timed out after 10 seconds; forcing socket close")
         :gun.close(conn_pid)
     end
   end


### PR DESCRIPTION
## How to test

This PR should be tested with Aligned running on the branch feat/notify-user-after-replacement-message.

With this change, after bumping your fee, the exposed metric failed_proofs_count should be zero (or remain unchanged) in http://localhost:4005/metrics.