### PR TITLE
fix(contracts): check transfersEnabled in _update function

### DIFF
--- a/contracts/src/ZkArcadeNft.sol
+++ b/contracts/src/ZkArcadeNft.sol
@@ -78,12 +78,13 @@ contract ZkArcadeNft is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgradeable {
         return tokenId;
     }
 
-    function transferFrom(address from, address to, uint256 tokenId) public override {
-        if (!transfersEnabled) {
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address from) {
+        from = _ownerOf(tokenId);
+        // only block actual transfers (not mint or burn)
+        if (!transfersEnabled && from != address(0) && to != address(0)) {
             revert TransfersPaused();
         }
-
-        super.transferFrom(from, to, tokenId);
+        return super._update(to, tokenId, auth);
     }
 
     function _baseURI() internal view override returns (string memory) {

--- a/contracts/src/ZkArcadePublicNft.sol
+++ b/contracts/src/ZkArcadePublicNft.sol
@@ -74,11 +74,13 @@ contract ZkArcadePublicNft is ERC721Upgradeable, UUPSUpgradeable, OwnableUpgrade
         return tokenId;
     }
 
-    function transferFrom(address from, address to, uint256 tokenId) public override {
-        if (!transfersEnabled) {
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address from) {
+        from = _ownerOf(tokenId);
+        // only block actual transfers (not mint or burn)
+        if (!transfersEnabled && from != address(0) && to != address(0)) {
             revert TransfersPaused();
         }
-        super.transferFrom(from, to, tokenId);
+        return super._update(to, tokenId, auth);
     }
 
     // ======== View Functions ========


### PR DESCRIPTION
# How to Test

1. Run zk arcade
2. Claim the NFT with your wallet
3. Try to tranfer the NFT using the following cast command

```
cast send <NFT_PROXY_ADDRESS> \
    "transferFrom(address,address,uint256)" \
   <YOUR_ADDRESS> \
    0x9109Bbd2181cb8e4E8fF996F3204e69A575103D0 \
    0 \
    --rpc-url http://localhost:8545 \
    --interactive
```

You should see the following error

```
Error: Failed to estimate gas: server returned an error response: error code 3: execution reverted: custom error 0x6ab17e05, data: "0x6ab17e05": TransfersPaused
```