### PR TITLE
chore: add build for macos x86

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
             artifact_name: x86
           - os: macos-latest
             artifact_name: arm64
+          - os: macos-15-intel
+            artifact_name: macos_x86
           - os: ubuntu-latest
             artifact_name: windows
             target: x86_64-pc-windows-gnu

--- a/install_beast.sh
+++ b/install_beast.sh
@@ -14,14 +14,17 @@ CURRENT_TAG=$(curl -s -L \
   https://api.github.com/repos/yetanotherco/zk_arcade/releases/latest \
   | grep '"tag_name":' | awk -F'"' '{print $4}')
 RELEASE_URL="https://github.com/yetanotherco/zk_arcade/releases/download/$CURRENT_TAG/"
+OS=$(uname -s)
 ARCH=$(uname -m)
 
-if [ "$ARCH" == "x86_64" ]; then
+if [ "$OS" == "Linux" ] && [ "$ARCH" == "x86_64" ]; then
     FILE="beast_x86"
-elif [ "$ARCH" == "arm64" ]; then
+elif [ "$OS" == "Darwin" ] && [ "$ARCH" == "arm64" ]; then
     FILE="beast_arm64"
+elif [ "$OS" == "Darwin" ] && [ "$ARCH" == "x86_64" ]; then
+    FILE="beast_macos_x86"
 else
-    echo "Unsupported architecture: $ARCH"
+    echo "Unsupported OS/architecture combination: $OS/$ARCH"
     exit 1
 fi
 

--- a/install_beast_cloudflare.sh
+++ b/install_beast_cloudflare.sh
@@ -10,14 +10,17 @@ BEAST_BIN_DIR="$BEAST_DIR/bin"
 BEAST_BIN_PATH="$BEAST_BIN_DIR/beast"
 CURRENT_VERSION="v1_0_1"
 RELEASE_URL="https://downloads.zkarcade.com/$CURRENT_VERSION/"
+OS=$(uname -s)
 ARCH=$(uname -m)
 
-if [ "$ARCH" == "x86_64" ]; then
+if [ "$OS" == "Linux" ] && [ "$ARCH" == "x86_64" ]; then
     FILE="beast_x86"
-elif [ "$ARCH" == "arm64" ]; then
+elif [ "$OS" == "Darwin" ] && [ "$ARCH" == "arm64" ]; then
     FILE="beast_arm64"
+elif [ "$OS" == "Darwin" ] && [ "$ARCH" == "x86_64" ]; then
+    FILE="beast_macos_x86"
 else
-    echo "Unsupported architecture: $ARCH"
+    echo "Unsupported OS/architecture combination: $OS/$ARCH"
     exit 1
 fi
 

--- a/install_beast_sepolia.sh
+++ b/install_beast_sepolia.sh
@@ -14,14 +14,17 @@ CURRENT_TAG=$(curl -s -L \
   https://api.github.com/repos/yetanotherco/zk_arcade/releases/latest \
   | grep '"tag_name":' | awk -F'"' '{print $4}')
 RELEASE_URL="https://github.com/yetanotherco/zk_arcade/releases/download/$CURRENT_TAG/"
+OS=$(uname -s)
 ARCH=$(uname -m)
 
-if [ "$ARCH" == "x86_64" ]; then
-    FILE="beast_sepolia_x86"
-elif [ "$ARCH" == "arm64" ]; then
-    FILE="beast_sepolia_arm64"
+if [ "$OS" == "Linux" ] && [ "$ARCH" == "x86_64" ]; then
+    FILE="beast_x86"
+elif [ "$OS" == "Darwin" ] && [ "$ARCH" == "arm64" ]; then
+    FILE="beast_arm64"
+elif [ "$OS" == "Darwin" ] && [ "$ARCH" == "x86_64" ]; then
+    FILE="beast_macos_x86"
 else
-    echo "Unsupported architecture: $ARCH"
+    echo "Unsupported OS/architecture combination: $OS/$ARCH"
     exit 1
 fi
 


### PR DESCRIPTION
Note:  These artifacts do not change the name to keep retrocompatibility
```
          - os: ubuntu-22.04
            artifact_name: x86
          - os: macos-latest
            artifact_name: arm64
```
