### PR TITLE
fix(metrics): increment minted nfts only once

### DIFF
--- a/web/lib/zk_arcade/accounts.ex
+++ b/web/lib/zk_arcade/accounts.ex
@@ -195,9 +195,12 @@ defmodule ZkArcade.Accounts do
         if updated_tokens == current_tokens do
           {:ok, wallet}
         else
-          wallet
-          |> Wallet.token_ids_changeset(%{owned_token_ids: updated_tokens})
-          |> Repo.update()
+          case wallet |> Wallet.token_ids_changeset(%{owned_token_ids: updated_tokens}) |> Repo.update() do
+            {:ok, updated_wallet} ->
+              ZkArcade.PrometheusMetrics.increment_nft_mints()
+              {:ok, updated_wallet}
+            {:error, changeset} -> {:error, changeset}
+          end
         end
 
       {:error, :not_found} ->

--- a/web/lib/zk_arcade/nft_poller.ex
+++ b/web/lib/zk_arcade/nft_poller.ex
@@ -134,9 +134,7 @@ defmodule ZkArcade.NftPoller do
 
   defp maybe_add_token(address, token_id) do
     case Accounts.add_owned_token(address, token_id) do
-      {:ok, _} ->
-        ZkArcade.PrometheusMetrics.increment_nft_mints()
-        :ok
+      {:ok, _} -> :ok
       {:error, reason} -> Logger.warning("Failed to add token #{token_id} for #{address}: #{inspect(reason)}")
     end
   end


### PR DESCRIPTION
This PR fixes a bug where the metric of minted nfts were being increased for every event, even if the event was already seen